### PR TITLE
fix svm openapi

### DIFF
--- a/svm/balances.mdx
+++ b/svm/balances.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Balances'
 sidebarTitle: 'Balances'
-openapi: '/svm/openapi/balances.json GET /v1/svm/balances/{uri}'
+openapi: '/svm/openapi/balances.json GET /beta/svm/balances/{uri}'
 ---
 
 The Token Balances API provides accurate and fast real time balances of the native, SPL and SPL-2022 tokens of accounts on supported SVM blockchains.

--- a/svm/openapi/balances.json
+++ b/svm/openapi/balances.json
@@ -14,7 +14,7 @@
     }
   ],
   "paths": {
-    "/v1/svm/balances/{uri}": {
+    "/beta/svm/balances/{uri}": {
       "get": {
         "tags": [
           "svm-balances"
@@ -23,6 +23,15 @@
         "description": "Get token balances for a given SVM address",
         "operationId": "getSvmBalances",
         "parameters": [
+          {
+            "name": "X-Sim-Api-Key",
+            "in": "header",
+            "description": "API key to access the service",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "uri",
             "in": "path",
@@ -56,15 +65,6 @@
             "in": "query",
             "description": "Pagination offset from previous response",
             "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "X-Sim-Api-Key",
-            "in": "header",
-            "description": "API key to access the service",
-            "required": true,
             "schema": {
               "type": "string"
             }
@@ -241,20 +241,8 @@
           }
         }
       }
-    },
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-Sim-Api-Key"
-      }
     }
   },
-  "security": [
-    {
-      "ApiKeyAuth": []
-    }
-  ],
   "tags": [
     {
       "name": "svm-balances",

--- a/svm/openapi/transactions.json
+++ b/svm/openapi/transactions.json
@@ -14,7 +14,7 @@
     }
   ],
   "paths": {
-    "/v1/svm/transactions/{uri}": {
+    "/beta/svm/transactions/{uri}": {
       "get": {
         "tags": [
           "svm-transactions"
@@ -23,6 +23,15 @@
         "description": "Get transactions for a given SVM address",
         "operationId": "getSvmTransactions",
         "parameters": [
+          {
+            "name": "X-Sim-Api-Key",
+            "in": "header",
+            "description": "API key to access the service",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "uri",
             "in": "path",
@@ -47,15 +56,6 @@
             "in": "query",
             "description": "Pagination offset from previous response",
             "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "X-Sim-Api-Key",
-            "in": "header",
-            "description": "API key to access the service",
-            "required": true,
             "schema": {
               "type": "string"
             }
@@ -202,20 +202,8 @@
           }
         }
       }
-    },
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-Sim-Api-Key"
-      }
     }
   },
-  "security": [
-    {
-      "ApiKeyAuth": []
-    }
-  ],
   "tags": [
     {
       "name": "svm-transactions",

--- a/svm/transactions.mdx
+++ b/svm/transactions.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Transactions'
 sidebarTitle: 'Transactions'
-openapi: '/svm/openapi/transactions.json GET /v1/svm/transactions/{uri}'
+openapi: '/svm/openapi/transactions.json GET /beta/svm/transactions/{uri}'
 ---
 
 The Transactions Endpoint allows for quick and accurate lookup of transactions associated with an address.


### PR DESCRIPTION
### TL;DR

Updated SVM API endpoints from `/v1/` to `/beta/` and reorganized API key header positioning.

### What changed?

- Changed API endpoint paths from `/v1/svm/balances/{uri}` to `/beta/svm/balances/{uri}`
- Changed API endpoint paths from `/v1/svm/transactions/{uri}` to `/beta/svm/transactions/{uri}`
- Moved the `X-Sim-Api-Key` header parameter to be the first parameter in the API specifications
- Removed the `securitySchemes` and `security` sections from the OpenAPI specifications
- Updated the corresponding MDX files to reflect the new endpoint paths

### How to test?

1. Verify that the API endpoints work correctly with the new `/beta/` path prefix
2. Confirm that API requests with the `X-Sim-Api-Key` header are properly authenticated
3. Check that the documentation correctly displays the updated endpoints

### Why make this change?

This change reflects the beta status of the SVM API endpoints and standardizes the parameter ordering in the OpenAPI specifications. Moving the API key header to be the first parameter improves documentation clarity, while the path change accurately represents the current development stage of these endpoints.