### PR TITLE
Use chains parameter for EVM endpoints

### DIFF
--- a/evm/balances.mdx
+++ b/evm/balances.mdx
@@ -13,7 +13,7 @@ The Token Balances API provides accurate and fast real time balances of the nati
 
 <Note>
   The Balances API only returns balances for certain low latency chains by default.
-  To fetch balances for _all_ supported chains, use the `?chains_ids=all` query parameter.
+  To fetch balances for _all_ supported chains, use the `?chains=all` query parameter.
 </Note>
 
 <Accordion title="Supported Chains">

--- a/evm/openapi/balances.json
+++ b/evm/openapi/balances.json
@@ -42,9 +42,9 @@
             }
           },
           {
-            "name": "chain_ids",
+            "name": "chains",
             "in": "query",
-            "description": "A comma separated list of chain_ids or tags for blockchains to get balances for. Examples: chain_ids=1,8453,10, chain_ids=mainnet,testnet.  Only balances for blockchains tagged with all the specified tags are returned. Please see the response of the /chains endpoint for the tags on each blockchain.",
+            "description": "A comma separated list of chain names, ids, or tags to get balances for. Examples: chains=ethereum,polygon, chains=1,8453,10, chains=mainnet,testnet.  Only balances for blockchains tagged with all the specified tags are returned. Please see the response of the /chains endpoint for the tags on each blockchain.",
             "required": false,
             "schema": {
               "type": "string",

--- a/evm/openapi/collectibles.json
+++ b/evm/openapi/collectibles.json
@@ -132,10 +132,10 @@
             "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
           },
           {
-            "name": "chain_ids",
+            "name": "chains",
             "in": "query",
             "required": false,
-            "description": "A comma-separated list of chain IDs (e.g., `?chain_ids=1,137`) or chain names (e.g., `?chain_ids=ethereum,polygon`) to filter collectibles by. If not provided, collectibles from all `default` chains for the address are returned. See [Supported Chains](#supported-chains) for more information.",
+            "description": "A comma-separated list of chain names or ids to filter collectibles by (e.g., `?chains=ethereum,polygon` or `?chains=1,137`). If not provided, collectibles from all `default` chains for the address are returned. See [Supported Chains](#supported-chains) for more information.",
             "schema": {
               "type": "string"
             }

--- a/evm/openapi/token-info.json
+++ b/evm/openapi/token-info.json
@@ -41,9 +41,9 @@
             }
           },
           {
-            "name": "chain_ids",
+            "name": "chains",
             "in": "query",
-            "description": "Either 'all' or a comma separated list of chain ids to get token info for",
+            "description": "Either 'all' or a comma separated list of chain names or ids to get token info for",
             "required": true,
             "schema": {
               "type": "string",

--- a/evm/openapi/transactions.json
+++ b/evm/openapi/transactions.json
@@ -42,9 +42,9 @@
             }
           },
           {
-            "name": "chain_ids",
+            "name": "chains",
             "in": "query",
-            "description": "A comma separated list of chain_ids or tags for blockchains to get transactions for. Examples: chain_ids=1,8453,10, chain_ids=mainnet,testnet.",
+            "description": "A comma separated list of chain names, ids, or tags to get transactions for. Examples: chains=ethereum,polygon, chains=1,8453,10, chains=mainnet,testnet.",
             "required": false,
             "schema": {
               "type": "string",

--- a/evm/token-info.mdx
+++ b/evm/token-info.mdx
@@ -17,9 +17,9 @@ The Tokens API provides metadata and realtime pricing information for native and
 - Logo URLs when available
 
 <Note>
-  The `?chain_ids` query parameter is mandatory.
-  To fetch tokens for _all_ supported chains, pass the `?chain_ids=all` query parameter.
-  You can also specify specific chains with `?chain_ids=11,250,1`.
+  The `?chains` query parameter is mandatory.
+  To fetch tokens for _all_ supported chains, pass the `?chains=all` query parameter.
+  You can also specify specific chains with `?chains=ethereum,polygon` or `?chains=11,250,1`.
 </Note>
 
 <Accordion title="Supported Chains">


### PR DESCRIPTION
## Summary
- rename `chain_ids` query param to `chains` in EVM OpenAPI specs
- update EVM docs to describe the new `?chains` parameter

## Testing
- `python3 -m json.tool evm/openapi/balances.json`
- `python3 -m json.tool evm/openapi/transactions.json`
- `python3 -m json.tool evm/openapi/token-info.json`
- `python3 -m json.tool evm/openapi/collectibles.json`
