### PR TITLE
Review balances endpoint feedback

### DIFF
--- a/evm/openapi/balances.json
+++ b/evm/openapi/balances.json
@@ -109,10 +109,35 @@
                       "address": "native",
                       "amount": "605371497350928252303",
                       "chain": "ethereum",
+                      "chain_id": 1,
                       "decimals": 18,
                       "price_usd": 3042.816964922323,
                       "symbol": "ETH",
-                      "value_usd": 1842034.6622198338
+                      "value_usd": 1842034.6622198338,
+                      "name": "Ethereum",
+                      "pool_size": 125000000.5,
+                      "low_liquidity": false,
+                      "token_metadata": {
+                        "logo": "https://assets.coingecko.com/coins/images/279/small/ethereum.png",
+                        "url": "https://ethereum.org"
+                      }
+                    },
+                    {
+                      "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                      "amount": "1500000000",
+                      "chain": "ethereum",
+                      "chain_id": 1,
+                      "decimals": 6,
+                      "price_usd": 0.9998,
+                      "symbol": "USDC",
+                      "value_usd": 1499.7,
+                      "name": "USD Coin",
+                      "pool_size": 450000000.0,
+                      "low_liquidity": false,
+                      "token_metadata": {
+                        "logo": "https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png",
+                        "url": "https://www.circle.com/en/usdc"
+                      }
                     }
                   ],
                   "next_offset": "dKMBWDLqM7vlyn5OMEXsLWp0nI4AAAABA5JLazNO7x4poVGqUwsgxgqvvIg",


### PR DESCRIPTION
The example response for the `balances` endpoint in `evm/openapi/balances.json` was updated to align with the OpenAPI schema and address feedback.

*   The `token_metadata` field, including `logo` and `url`, was added to the example for the `ETH` balance. This ensures the example accurately reflects responses when the `metadata` query parameter is used.
*   Other schema-defined fields such as `chain_id`, `name`, `pool_size`, and `low_liquidity` were included.
*   A second token example (`USDC`) was added to the response array, using realistic values, to better illustrate the structure with multiple balances.

These changes improve the clarity and completeness of the documentation example, showing the `token_metadata` object as expected when requested.