### PR TITLE
Add note to documentation

### DIFF
--- a/idx/db.mdx
+++ b/idx/db.mdx
@@ -43,6 +43,10 @@ An event defined as `event PoolCreated(address pool, address token0, address tok
 
 When you inspect your database, you will see both the clean views you should query and the internal tables with random suffixes. **Always query the views (lowercase `snake_case` names).**
 
+<Note>
+**Database Limitations**: Currently, Sim IDX only supports creating new rows in the database, not updates to existing rows. This means that once data is indexed and stored, it cannot be modified through the framework. We are exploring options to support updates in future versions.
+</Note>
+
 ## Common Database Operations
 
 Here are some common `psql` commands you can use to inspect your database:


### PR DESCRIPTION
Add a note to database documentation clarifying current limitations on row updates.

---

[Slack Thread](https://duneanalytics.slack.com/archives/C092XE9AVDJ/p1752247190635599?thread_ts=1752247190.635599&cid=C092XE9AVDJ)