### PR TITLE
Update sim listeners evaluate documentation

### DIFF
--- a/idx/cli.mdx
+++ b/idx/cli.mdx
@@ -142,7 +142,8 @@ Runs your listener locally against historical main-chain data so you can verify 
 sim listeners evaluate \
   --start-block <START_BLOCK> \
   --chain-id <CHAIN_ID> \
-  --end-block <END_BLOCK>
+  --end-block <END_BLOCK> \
+  --listeners <LISTENER_CONTRACT>
 ```
 
 <Info>
@@ -154,6 +155,7 @@ sim listeners evaluate \
 | `--start-block` | Yes | First block to process. |
 | `--chain-id` | Conditional* | Chain ID to test against. If omitted, Sim tries to infer it from your `addTrigger` definitions. Required when your listener has triggers on multiple chains. |
 | `--end-block` | No | Last block to process. Provide this if you want to replay more than one block and observe state changes over a range. |
+| `--listeners` | No | Specific listener contract to evaluate. Accepts any listener contract within any of the Solidity files in `/listener/src`. If omitted, the command will run all listener contracts in all files. The command will fail if you specify an unknown listener. |
 
 The command compiles your listener, executes the triggers across the block range, and prints a summary such as:
 

--- a/idx/guides/decode-any-contract.mdx
+++ b/idx/guides/decode-any-contract.mdx
@@ -107,7 +107,8 @@ Find a block number on Etherscan where a Moonbirds transaction occurred and use 
 ```bash
 sim listeners evaluate \
   --chain-id=1 \
-  --start-block=22830504
+  --start-block=22830504 \
+  --listeners=Listener
 ```
 
 If the setup is correct, the output will be a JSON object containing a list of decoded Moonbirds events in the `events` array and an empty `errors` array.

--- a/idx/guides/swap-sample-abi.mdx
+++ b/idx/guides/swap-sample-abi.mdx
@@ -100,6 +100,7 @@ Before deploying, replay historical chain data to confirm that the new triggers 
 sim listeners evaluate \
   --chain-id 1 \
   --start-block <BLOCK_NUMBER> \
+  --listeners=Listener
   # --end-block   <BLOCK_NUMBER>   # optional, evaluates a single block if omitted
 ```
 

--- a/idx/listener.mdx
+++ b/idx/listener.mdx
@@ -288,11 +288,12 @@ Use `sim listeners evaluate` to see how your listener reacts to real onchain dat
 sim listeners evaluate \
   --chain-id 1 \
   --start-block 12369662 \
-  --end-block 12369670
+  --end-block 12369670 \
+  --listeners=Listener
 ```
 
 <Note>
-Visit the [`sim listeners evaluate`](/idx/cli#sim-listeners-evaluate) documentation to learn more about the available flags.
+The `--listeners=Listener` flag specifies which listener contract to evaluate. You can update this to match your specific listener contract name. Visit the [`sim listeners evaluate`](/idx/cli#sim-listeners-evaluate) documentation to learn more about the available flags.
 </Note>
 
 ## Next Steps


### PR DESCRIPTION
Update documentation for `sim listeners evaluate` command to reflect the new `--listeners` flag.

---

[Slack Thread](https://duneanalytics.slack.com/archives/C092XE9AVDJ/p1752583078211969?thread_ts=1752583078.211969&cid=C092XE9AVDJ)