### PR TITLE
Standardize "trigger" term in docs

### DIFF
--- a/idx/apis.mdx
+++ b/idx/apis.mdx
@@ -125,7 +125,7 @@ This endpoint uses a simple SQL query to fetch the most recent pools. The `LIMIT
 ### Adding the Owner Changed Endpoint
 
 <Note>
-Before continuing, make sure you've added support for the `OwnerChanged` event in your listener contract by following the ["Hooking into more functions and events"](/idx/listener#hooking-into-more-functions-and-events) section of the Listener guide and then running:
+Before continuing, make sure you've added support for the `OwnerChanged` event in your listener contract by following the ["Triggering more functions and events"](/idx/listener#trigger-onchain-activity) section of the Listener guide and then running:
 
 ```bash
 sim build

--- a/idx/build-with-ai.mdx
+++ b/idx/build-with-ai.mdx
@@ -31,7 +31,7 @@ Read the docs from here https://docs.sim.dune.com/llms-full.txt
 ## Framework Overview
 - Sim idx is Dune's blockchain event indexing framework
 - Projects have two main components: Solidity listeners and TypeScript APIs  
-- Listeners hook into blockchain events, APIs serve indexed data
+- Listeners trigger on blockchain events, APIs serve indexed data
 
 ## Project Structure
 - `listeners/` - Solidity contracts for event listening

--- a/idx/changelog.mdx
+++ b/idx/changelog.mdx
@@ -9,7 +9,7 @@ description: "Product updates and announcements"
   With CLI version v0.0.79 and upwards, there will be a breaking change that impacts users who import and use generated structs from the ABI.
 
   **Why this change was needed:**
-  The same struct name can be used across different contracts (example: `GPv2Trade.Data` and `GPv2Interaction.Data` within the same ABI) with different definitions. Using just the struct name for generated structs prevented proper hooking on protocols like CoW Swap.
+  The same struct name can be used across different contracts (example: `GPv2Trade.Data` and `GPv2Interaction.Data` within the same ABI) with different definitions. Using just the struct name for generated structs prevented proper triggering on protocols like CoW Swap.
 
   **What changed:**
   We now include the contract name as part of the struct name in the generated Solidity file associated with the ABI. Instead of using `$AbiName$StructName` for the names, we now use `$AbiName$ContractName$StructName`.
@@ -63,5 +63,5 @@ description: "Product updates and announcements"
   - Pre-process or validate function inputs before execution
   - Set up state or conditions that the main function execution will depend on
 
-  For detailed implementation examples and usage patterns, see the [Function Hooks documentation](https://docs.sim.dune.com/idx/listener#function-hooks).
+  For detailed implementation examples and usage patterns, see the [Function Triggers documentation](https://docs.sim.dune.com/idx/listener#function-triggers).
 </Update>

--- a/idx/changelog.mdx
+++ b/idx/changelog.mdx
@@ -63,5 +63,5 @@ description: "Product updates and announcements"
   - Pre-process or validate function inputs before execution
   - Set up state or conditions that the main function execution will depend on
 
-  For detailed implementation examples and usage patterns, see the [Function Triggers documentation](https://docs.sim.dune.com/idx/listener#function-triggers).
+  For detailed implementation examples and usage patterns, see the [Function Triggers documentation](/idx/listener#function-triggers).
 </Update>

--- a/idx/guides/decode-any-contract.mdx
+++ b/idx/guides/decode-any-contract.mdx
@@ -62,7 +62,7 @@ The CLI will parse the new ABI and generate a `Moonbirds.sol` file in `listeners
 
 ## 4. Configure the Listener to Decode All Events
 
-Open `listeners/src/Main.sol`. This is the core file where you define your indexing logic. We need to make two small changes to hook into the generated Moonbirds bindings.
+Open `listeners/src/Main.sol`. This is the core file where you define your indexing logic. We need to make two small changes to trigger on the generated Moonbirds bindings.
 
 The `Moonbirds.sol` file generated in the previous step includes a special abstract contract called `Moonbirds$EmitAllEvents`. By inheriting from this contract, your listener automatically gains the ability to:
 1.  React to every event defined in the Moonbirds ABI.

--- a/idx/guides/swap-sample-abi.mdx
+++ b/idx/guides/swap-sample-abi.mdx
@@ -22,7 +22,7 @@ Running [`sim abi codegen`](/idx/cli#sim-abi-codegen) removes the now-missing Fa
 
 Start by obtaining the ABI for the contract you want to observe. The most common approach is to open the contract page on a blockchain explorer such as Etherscan, Basescan or Polygonscan and click the **Contract** tab. From there select **Contract ABI** and copy the full JSON blob to your clipboard.
 
-For the purposes of this guide we'll hook into the [Ethereum USDC contract](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48#code).
+For the purposes of this guide we'll trigger on the [Ethereum USDC contract](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48#code).
 
 <Frame>
   <img src="/images/idx/guides/swap-abi/usdc-contract-abi.png" />

--- a/idx/guides/uniswap-x-swaps.mdx
+++ b/idx/guides/uniswap-x-swaps.mdx
@@ -884,7 +884,7 @@ import {IReactor} from "./interfaces/IReactor.sol";
 import {getMetadata} from "./utils/MetadataUtils.sol";
 import {FeeInjector} from "./libs/FeeInjector.sol";
 
-// This contract defines our triggers. We're listening to the pre-execution hooks
+// This contract defines our triggers. We're listening to the pre-execution triggers
 // of the four main functions on Uniswap X Reactor contracts across Ethereum, Polygon, and Base.
 contract Triggers is BaseTriggers {
     function triggers() external virtual override {

--- a/idx/listener.mdx
+++ b/idx/listener.mdx
@@ -147,22 +147,22 @@ function onCreatePoolFunction(...) external override {
 
 After deploying these changes, your `pool_created` table will automatically include the new `block_number` column.
 
-## Hook into Onchain Activity
+## Trigger Onchain Activity
 
-Sim IDX can hook into contract events as well as function calls, both before and after they execute. This allows you to capture a wide range of onchain activity.
+Sim IDX can trigger on contract events as well as function calls, both before and after they execute. This allows you to capture a wide range of onchain activity.
 
-To add a new hook to your listener, you'll follow a simple, five-step process:
+To add a new trigger to your listener, you'll follow a simple, five-step process:
 
-1.  **Discover the Hook**: Find the abstract contract for your target function or event in the generated files.
+1.  **Discover the Trigger**: Find the abstract contract for your target function or event in the generated files.
 2.  **Extend the Listener**: Add the abstract contract to your listener's inheritance list.
 3.  **Define a New Event**: Create a Solidity event to define your database schema.
 4.  **Implement the Handler**: Write the function required by the abstract contract to process the data and emit your event.
-5.  **Register the Trigger**: Call `addTrigger` in your `Triggers` contract to activate the hook.
+5.  **Register the Trigger**: Call `addTrigger` in your `Triggers` contract to activate the trigger.
 
-Let's walk through an example of adding a new event hook to the sample app's `Listener` contract.
+Let's walk through an example of adding a new event trigger to the sample app's `Listener` contract.
 We will extend the `Listener` to also index the `OwnerChanged` event from the Uniswap V3 Factory.
 
-### 1. Discover the Hook
+### 1. Discover the Trigger
 
 Look inside `listeners/lib/sim-idx-generated/UniswapV3Factory.sol`. You will find an abstract contract for the `OwnerChanged` event.
 
@@ -227,9 +227,9 @@ addTrigger(
 );
 ```
 
-## Function Hooks
+## Function Triggers
 
-The framework supports both post-execution and pre-execution function hooks.
+The framework supports both post-execution and pre-execution function triggers.
 
 **Post-Execution:** This is what the sample app uses with `onCreatePoolFunction`. The handler is called *after* the contract's function completes, so it has access to both `inputs` and `outputs`.
 

--- a/idx/listener/patterns.mdx
+++ b/idx/listener/patterns.mdx
@@ -72,7 +72,7 @@ contract MyBlockListener is Raw$OnBlock {
 }
 ```
 
-The framework also provides abstract contracts for `Raw$OnCall` and `Raw$OnLog`, allowing you to create global hooks for every function call or every event log on a chain.
+The framework also provides abstract contracts for `Raw$OnCall` and `Raw$OnLog`, allowing you to create global triggers for every function call or every event log on a chain.
 
 ## Using Interfaces
 


### PR DESCRIPTION
Standardize documentation terminology by replacing "hook" with "trigger" and updating all relevant internal links.

---

[Slack Thread](https://duneanalytics.slack.com/archives/C092XE9AVDJ/p1752723571490679?thread_ts=1752723571.490679&cid=C092XE9AVDJ)