### PR TITLE
Add honeypot detection disclaimer to docs

### DIFF
--- a/token-filtering.mdx
+++ b/token-filtering.mdx
@@ -11,8 +11,6 @@ Sim APIs provide comprehensive token metadata and liquidity data to help you imp
 We don't offer direct spam filtering because definitions of spam are varying and subjective.
 Instead, we provide the best objective measure that we're aware of—liquidity data—to allow developers to filter downstream based on their specific requirements.
 
-**Important**: We do not detect or flag honeypots, scam tokens, or other malicious contracts. Our APIs will return price and liquidity data for any token that has trading activity, regardless of whether it's a legitimate project or a scam. The presence of price data does not indicate that a token is safe to trade or that transactions will be successful.
-
 By grounding filtering decisions in measurable, onchain liquidity, rather than subjective labels, our method offers several advantages:
 
 - **Objective**: We provide liquidity metrics rather than subjective spam classifications
@@ -20,6 +18,12 @@ By grounding filtering decisions in measurable, onchain liquidity, rather than s
 - **Flexible**: All filtering data is provided, allowing you to implement custom logic that fits your use case
 - **Transparent**: You have full visibility into the data used for filtering decisions
 - **Adaptable**: Your filtering criteria can evolve with your application's needs
+
+<Note>
+**We do not detect or flag honeypots, scam tokens, or other malicious contracts**.
+Our APIs will return price and liquidity data for any token that has trading activity.
+The presence of price data does not indicate that a token is safe to trade or that transactions will be successful.
+</Note>
 
 ## Supported APIs
 

--- a/token-filtering.mdx
+++ b/token-filtering.mdx
@@ -11,6 +11,8 @@ Sim APIs provide comprehensive token metadata and liquidity data to help you imp
 We don't offer direct spam filtering because definitions of spam are varying and subjective.
 Instead, we provide the best objective measure that we're aware of—liquidity data—to allow developers to filter downstream based on their specific requirements.
 
+**Important**: We do not detect or flag honeypots, scam tokens, or other malicious contracts. Our APIs will return price and liquidity data for any token that has trading activity, regardless of whether it's a legitimate project or a scam. The presence of price data does not indicate that a token is safe to trade or that transactions will be successful.
+
 By grounding filtering decisions in measurable, onchain liquidity, rather than subjective labels, our method offers several advantages:
 
 - **Objective**: We provide liquidity metrics rather than subjective spam classifications


### PR DESCRIPTION
Add a note to the token filtering documentation to clarify that honeypots and scam tokens are not detected.

This change was prompted by a user flagging a scam token (ETHG) showing a balance in SIM, leading to confusion about the platform's ability to detect malicious contracts. The added text clarifies that SIM APIs return data for any token with trading activity, regardless of legitimacy, and that price data does not indicate safety or success of transactions.

---

[Slack Thread](https://duneanalytics.slack.com/archives/C0766JKCP89/p1753447429249699?thread_ts=1753447429.249699&cid=C0766JKCP89) • [Open in Web](https://www.cursor.com/agents?id=bc-340f6bc4-13a2-4c55-97d2-055b7ebee4a3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-340f6bc4-13a2-4c55-97d2-055b7ebee4a3)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)