### PR TITLE
Update sim cli output in docs

### DIFF
--- a/idx.mdx
+++ b/idx.mdx
@@ -42,6 +42,8 @@ This guide will walk you through installing the CLI, initializing a sample proje
   [INFO] Installing sim to /root/.local/bin/sim
   [INFO] sim CLI installed successfully!
   [INFO] Added sim CLI to PATH in /root/.bashrc
+  sim v0.0.83 (eaddf2 2025-06-22T18:01:14.000000000Z)
+  For more help, visit: <https://docs.sim.dune.com/idx>
   ```
 
   <Info>
@@ -60,6 +62,7 @@ This guide will walk you through installing the CLI, initializing a sample proje
   
   ```
   sim v0.0.53 (eaddf2 2025-06-22T18:01:14.000000000Z)
+  For more help, visit: <https://docs.sim.dune.com/idx>
   ```
 </Step>
 </Steps>
@@ -93,6 +96,8 @@ After successfully running init, you'll see:
 
 ```text
 INFO sim::init: Successfully initialized a new Sim IDX app
+sim v0.0.83 (eaddf2 2025-06-22T18:01:14.000000000Z)
+For more help, visit: <https://docs.sim.dune.com/idx>
 ```
 
 ## Authentication
@@ -117,6 +122,8 @@ Once you've successfully authenticated, you'll see the following:
 INFO sim::authenticate: Verifying API Key...
 INFO sim::authenticate: API Key verified successfully.
 INFO sim::authenticate: API Key successfully saved.
+sim v0.0.83 (eaddf2 2025-06-22T18:01:14.000000000Z)
+For more help, visit: <https://docs.sim.dune.com/idx>
 ```
 
 ## Test Your Listener

--- a/idx/cli.mdx
+++ b/idx/cli.mdx
@@ -180,4 +180,6 @@ INFO deploy: {
   ],
   "errors": []
 }
+sim v0.0.83 (eaddf2 2025-06-22T18:01:14.000000000Z)
+For more help, visit: <https://docs.sim.dune.com/idx>
 ```

--- a/idx/listener/features.mdx
+++ b/idx/listener/features.mdx
@@ -291,5 +291,10 @@ Sim IDX supports several PostgreSQL index types. `BTREE` is the default and most
 The `sim build` command automatically validates your index definitions. If it detects an error in the syntax, it will fail the build and provide a descriptive error message.
 
 For example, if you misspell a column name:
-`Error: Cannot find column(s): 'block_numbr' in event PositionOwnerChanges`
+
+```text
+2025-08-06T10:14:31.112260Z ERROR sim: Error: Cannot find column(s): 'block_numbr' in event PositionOwnerChanges
+sim v0.0.83 (eaddf2 2025-06-22T18:01:14.000000000Z)
+For more help, visit: <https://docs.sim.dune.com/idx>
+```
 


### PR DESCRIPTION
Update Sim IDX documentation code snippets to include the CLI version before the help message, matching new CLI behavior.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C092XE9AVDJ/p1754479549217789?thread_ts=1754479549.217789&cid=C092XE9AVDJ)

<a href="https://cursor.com/background-agent?bcId=bc-b53150cc-82d0-4a41-b6af-9e27437f0ed4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b53150cc-82d0-4a41-b6af-9e27437f0ed4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

