### PR TITLE
Add sim version command to cli

### DIFF
--- a/idx/cli.mdx
+++ b/idx/cli.mdx
@@ -92,6 +92,18 @@ sim help
 
 You can also use `sim --help` or `sim -h` for the same functionality.
 
+#### `sim --version`
+
+Displays the current version of the Sim IDX CLI.
+
+```bash
+sim v0.0.86 (eaddf2 2025-06-22T18:01:14.000000000Z)
+```
+
+<Note>
+When you run a CLI command, the version will be at the bottom of the output.
+</Note>
+
 #### `sim abi`
 
 Provides a set of commands for managing contract ABIs and generating corresponding Solidity interfaces for use in your listener.


### PR DESCRIPTION
Adds `sim --version` command documentation to the CLI page to inform users how to check the CLI version.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C092XE9AVDJ/p1754480333006899?thread_ts=1754480333.006899&cid=C092XE9AVDJ)

<a href="https://cursor.com/background-agent?bcId=bc-61648328-61f2-4357-8c69-d77578399ede">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61648328-61f2-4357-8c69-d77578399ede">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

