### PR TITLE
Update quickstart docs to sim v0.0.86

### DIFF
--- a/idx.mdx
+++ b/idx.mdx
@@ -38,7 +38,7 @@ This guide will walk you through installing the CLI, initializing a sample proje
   You'll see the following output:
 
   ```text
-  [INFO] Installing sim CLI v0.0.53
+  [INFO] Installing sim CLI v0.0.86
   [INFO] Installing sim to /root/.local/bin/sim
   [INFO] sim CLI installed successfully!
   [INFO] Added sim CLI to PATH in /root/.bashrc
@@ -59,7 +59,7 @@ This guide will walk you through installing the CLI, initializing a sample proje
   You'll see:
   
   ```
-  sim v0.0.53 (eaddf2 2025-06-22T18:01:14.000000000Z)
+  sim v0.0.86 (eaddf2 2025-06-22T18:01:14.000000000Z)
   ```
 </Step>
 </Steps>


### PR DESCRIPTION
Update IDX quickstart documentation to reflect `sim v0.0.86` for improved accuracy.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C092XE9AVDJ/p1754480502938629?thread_ts=1754480502.938629&cid=C092XE9AVDJ)

<a href="https://cursor.com/background-agent?bcId=bc-8458c175-50dc-4105-9cac-a026b5f1563b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8458c175-50dc-4105-9cac-a026b5f1563b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

