### PR TITLE
Updating the Sim IDX documentation to mention the new required sim-id…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 **/.DS_Store
 .DS_Store
+# Also ignore variant filenames that sometimes appear
+**/.DS_Store?
+.DS_Store?

--- a/idx/build-with-ai.mdx
+++ b/idx/build-with-ai.mdx
@@ -91,7 +91,7 @@ Refer to the complete Sim IDX documentation for detailed information: `https://d
 ### Context and Inputs
 
 - Handler functions receive context objects (`EventContext`, `FunctionContext`) and typed input/output structs. To find the correct context objects, look in `lib/sim-idx-generated/`.
-- Access block/transaction data via `block.timestamp`, `ctx.txn.hash`, `ctx.txn.chainId`, etc.
+- Access block/transaction data via global helpers and context objects. Key values include `blockNumber()`, `block.timestamp`, `block.chainid`, and `ctx.txn.hash`. Note that `blockNumber()` is a function call.
 - Access event/function parameters via the `inputs` struct (e.g., `inputs.from`, `inputs.value`).
 
 ### Common Pitfalls & Solutions

--- a/idx/changelog.mdx
+++ b/idx/changelog.mdx
@@ -3,6 +3,42 @@ title: "Changelog"
 description: "Product updates and announcements"
 ---
 
+<Update label="August 19, 2025" description="CLI v0.0.95">
+  The Sim IDX framework has been updated with a new core import and a standardized function for accessing the block number in listener contracts.
+
+  **What's new:**
+
+  *   **Core Import:** All listeners should now include `import "sim-idx-sol/Simidx.sol";`. This file provides essential framework helpers required for core functionality.
+  *   **`blockNumber()` Function:** This function is now available to get the current block number. Use this instead of `block.number` for standardized access across all supported blockchains.
+
+  **Impact:**
+
+  To use the `blockNumber()` function, listeners must include the `sim-idx-sol/Simidx.sol` import. Attempting to call the function without the import will result in a compilation error. Going forward, all listener contracts should adopt this pattern to access core framework features.
+
+  ```diff Example Listener
+  // SPDX-License-Identifier: UNLICENSED
+  pragma solidity ^0.8.13;
+
+  + import "sim-idx-sol/Simidx.sol";
+    import "sim-idx-generated/Generated.sol";
+
+  contract MyListener is MyContract$OnMyEvent {
+      event MyEvent(uint64 chainId, uint256 blockNum);
+
+      function onMyEvent(
+          EventContext memory /*ctx*/,
+          MyContract$MyEventParams memory /*inputs*/
+      ) external override {
+          emit MyEvent(
+              uint64(block.chainid),
+  -           block.number
+  +           blockNumber()
+          );
+      }
+  }
+  ```
+</Update>
+
 <Update label="August 5, 2025" description="CLI v0.0.86">
   **New Feature: Custom Block Range Support**
 

--- a/idx/guides/uniswap-x-swaps.mdx
+++ b/idx/guides/uniswap-x-swaps.mdx
@@ -60,6 +60,7 @@ Sim IDX solves this with ABI-based triggers. Instead of targeting specific addre
 We achieve this with the `ChainIdAbi` helper in our `Triggers` contract. The code below sets up our listener to trigger on the `execute` function family for *any* contract on Ethereum, Unichain, and Base that implements the `IReactor` interface.
 
 ```solidity listeners/src/Main.sol
+import "sim-idx-sol/Simidx.sol";
 contract Triggers is BaseTriggers {
     function triggers() external virtual override {
         Listener listener = new Listener();
@@ -169,7 +170,7 @@ function emitUniswapXTrade(
         SwapData(
             uint64(block.chainid),
             txnHash,
-            uint64(block.number),
+            blockNumber(),
             uint64(block.timestamp),
             makingToken,
             makingAmount,

--- a/idx/listener.mdx
+++ b/idx/listener.mdx
@@ -90,6 +90,7 @@ The sample app places this logic in `listeners/src/UniswapV3FactoryListener.sol`
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
+import "sim-idx-sol/Simidx.sol";
 import "sim-idx-generated/Generated.sol";
 
 /// Index calls to the UniswapV3Factory.createPool function on Ethereum
@@ -168,12 +169,16 @@ function onCreatePoolFunction(...) external override {
         inputs.tokenA,
         inputs.tokenB,
         inputs.fee,
-        block.number // pass the new value
+        blockNumber() // pass the new value
     );
 }
 ```
 
 After deploying these changes, your `pool_created` table will automatically include the new `block_number` column.
+
+<Tip>
+Prefer `blockNumber()` over Solidity's `block.number` to standardize access across all supported blockchains.
+</Tip>
 
 ## Trigger Onchain Activity
 

--- a/idx/listener/errors.mdx
+++ b/idx/listener/errors.mdx
@@ -157,6 +157,7 @@ Implement struct flattening in your listener contract code (in `listeners/src/`)
         EmitSwapData memory emitData;
         emitData.chainId = uint64(block.chainid);
         emitData.txnHash = ctx.txn.hash;
+        emitData.blockNumber = blockNumber();
         // ... populate all other fields
 
         emit Swap(emitData);


### PR DESCRIPTION
…x-sol/Simidx.sol import for Listeners and the blockNumber() function to access to the block number for all supported blockchains in a standardized way.