### PR TITLE
Updating the Token Holders query parameter to offset

### DIFF
--- a/evm/openapi/token-holders.json
+++ b/evm/openapi/token-holders.json
@@ -158,10 +158,10 @@
             }
           },
           {
-            "name": "next_offset",
+            "name": "offset",
             "in": "query",
             "required": false,
-            "description": "Offset value for fetching the next page of results.",
+            "description": "Pagination token from the previous response's next_offset field.",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
Updating the Token Holders query parameter to offset (which is correct), not next_offset. Also making the description more clear.