### PR TITLE
Standardize path parameters to use {address} across EVM and SVM APIs.

### DIFF
--- a/evm/balances.mdx
+++ b/evm/balances.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Balances"
 description: "Access realtime token balances. Get comprehensive details about native and ERC20 tokens, including token metadata and USD valuations."
-openapi: "/evm/openapi/balances.json GET /v1/evm/balances/{uri}"
+openapi: "/evm/openapi/balances.json GET /v1/evm/balances/{address}"
 sidebarTitle: "Balances"
 ---
 

--- a/evm/build-a-realtime-wallet.mdx
+++ b/evm/build-a-realtime-wallet.mdx
@@ -776,7 +776,7 @@ async function getWalletBalances(walletAddress) {
 This function creates the API request using Node's `fetch`.
 It includes your `SIM_API_KEY` in the headers and sends a GET request to the `/v1/evm/balances/{address}` endpoint.
 
-The Balances API gives you access to various [_URL query parameters_](/evm/balances#parameter-uri) that you can include to modify the response.
+The Balances API gives you access to various [_URL query parameters_](/evm/balances) that you can include to modify the response.
 We have included `metadata=url,logo` to include a token's URL and logo.
 
 Next, modify your `app.get('/')` route handler in `server.js` to call `getWalletBalances` and pass the fetched tokens to your template:

--- a/evm/openapi/balances.json
+++ b/evm/openapi/balances.json
@@ -14,7 +14,7 @@
     }
   ],
   "paths": {
-    "/v1/evm/balances/{uri}": {
+    "/v1/evm/balances/{address}": {
       "get": {
         "tags": [
           "balances"
@@ -33,9 +33,9 @@
             }
           },
           {
-            "name": "uri",
+            "name": "address",
             "in": "path",
-            "description": "Wallet to get balances for",
+            "description": "Wallet address to get balances for",
             "required": true,
             "schema": {
               "type": "string",

--- a/evm/openapi/supported-chains.json
+++ b/evm/openapi/supported-chains.json
@@ -14,7 +14,7 @@
     }
   ],
   "paths": {
-    "/v1/evm/supported-chains/{uri}": {
+    "/v1/evm/supported-chains": {
       "get": {
         "tags": [
           "supported-chains"
@@ -27,15 +27,6 @@
             "name": "X-Sim-Api-Key",
             "in": "header",
             "description": "Used for authenticating requests. Provide an API key with a purpose of `Sim API`. See [Authentication](/#authentication).",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "uri",
-            "in": "path",
-            "description": "The endpoint to get supported chains for (e.g., 'balances', 'activity', 'token-info')",
             "required": true,
             "schema": {
               "type": "string"

--- a/evm/openapi/token-holders.json
+++ b/evm/openapi/token-holders.json
@@ -101,7 +101,7 @@
     }
   },
   "paths": {
-    "/v1/evm/token-holders/{chain_id}/{token_address}": {
+    "/v1/evm/token-holders/{chain_id}/{address}": {
       "get": {
         "summary": "Get Token Holders",
         "description": "Retrieves a list of token holders for a given token contract address on a specified blockchain.",
@@ -132,10 +132,10 @@
             "example": 8453
           },
           {
-            "name": "token_address",
+            "name": "address",
             "in": "path",
             "required": true,
-            "description": "The address of the token contract.",
+            "description": "The token contract address.",
             "schema": {
               "type": "string",
               "format": "address",

--- a/evm/openapi/token-info.json
+++ b/evm/openapi/token-info.json
@@ -14,7 +14,7 @@
     }
   ],
   "paths": {
-    "/v1/evm/token-info/{uri}": {
+    "/v1/evm/token-info/{address}": {
       "get": {
         "tags": [
           "token-info"
@@ -32,7 +32,7 @@
             }
           },
           {
-            "name": "uri",
+            "name": "address",
             "in": "path",
             "description": "The contract address of the token or 'native' for the native token of the chain",
             "required": true,

--- a/evm/openapi/transactions.json
+++ b/evm/openapi/transactions.json
@@ -14,7 +14,7 @@
     }
   ],
   "paths": {
-    "/v1/evm/transactions/{wallet_address}": {
+    "/v1/evm/transactions/{address}": {
       "get": {
         "tags": [
           "evm-transactions"
@@ -33,7 +33,7 @@
             }
           },
           {
-            "name": "wallet_address",
+            "name": "address",
             "in": "path",
             "description": "EVM wallet address",
             "required": true,

--- a/evm/token-holders.mdx
+++ b/evm/token-holders.mdx
@@ -2,7 +2,7 @@
 title: "Token Holders"
 sidebarTitle: "Token Holders"
 description: "Discover token distribution across ERC20 or ERC721 holders, ranked by wallet value."
-openapi: "/evm/openapi/token-holders.json GET /v1/evm/token-holders/{chain_id}/{token_address}"
+openapi: "/evm/openapi/token-holders.json GET /v1/evm/token-holders/{chain_id}/{address}"
 ---
 
 import { SupportedChains } from '/snippets/supported-chains.mdx';

--- a/evm/token-info.mdx
+++ b/evm/token-info.mdx
@@ -2,7 +2,7 @@
 title: "Token Info"
 sidebarTitle: "Token Info"
 description: "Get detailed metadata and realtime price information for any native asset or ERC20 token including symbol, name, decimals, supply information, USD pricing, and logo URLs."
-openapi: "/evm/openapi/token-info.json GET /v1/evm/token-info/{uri}"
+openapi: "/evm/openapi/token-info.json GET /v1/evm/token-info/{address}"
 ---
 
 import { SupportedChains } from '/snippets/supported-chains.mdx';

--- a/evm/transactions.mdx
+++ b/evm/transactions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Transactions"
 description: "Retrieve granular transaction details including block information, gas data, transaction types, and raw transaction values."
-openapi: "/evm/openapi/transactions.json GET /v1/evm/transactions/{wallet_address}"
+openapi: "/evm/openapi/transactions.json GET /v1/evm/transactions/{address}"
 sidebarTitle: "Transactions"
 ---
 

--- a/svm/balances.mdx
+++ b/svm/balances.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Balances'
 sidebarTitle: 'Balances'
-openapi: '/svm/openapi/balances.json GET /beta/svm/balances/{uri}'
+openapi: '/svm/openapi/balances.json GET /beta/svm/balances/{address}'
 ---
 
 The Token Balances API provides accurate and fast real time balances of the native, SPL and SPL-2022 tokens of accounts on supported SVM blockchains.

--- a/svm/openapi/balances.json
+++ b/svm/openapi/balances.json
@@ -14,7 +14,7 @@
     }
   ],
   "paths": {
-    "/beta/svm/balances/{uri}": {
+    "/beta/svm/balances/{address}": {
       "get": {
         "tags": [
           "svm-balances"
@@ -33,9 +33,9 @@
             }
           },
           {
-            "name": "uri",
+            "name": "address",
             "in": "path",
-            "description": "SVM address",
+            "description": "SVM wallet address",
             "required": true,
             "schema": {
               "type": "string",

--- a/svm/openapi/transactions.json
+++ b/svm/openapi/transactions.json
@@ -14,7 +14,7 @@
     }
   ],
   "paths": {
-    "/beta/svm/transactions/{uri}": {
+    "/beta/svm/transactions/{address}": {
       "get": {
         "tags": [
           "svm-transactions"
@@ -33,9 +33,9 @@
             }
           },
           {
-            "name": "uri",
+            "name": "address",
             "in": "path",
-            "description": "SVM address",
+            "description": "SVM wallet address",
             "required": true,
             "schema": {
               "type": "string",

--- a/svm/transactions.mdx
+++ b/svm/transactions.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Transactions'
 sidebarTitle: 'Transactions'
-openapi: '/svm/openapi/transactions.json GET /beta/svm/transactions/{uri}'
+openapi: '/svm/openapi/transactions.json GET /beta/svm/transactions/{address}'
 ---
 
 The Transactions Endpoint allows for quick and accurate lookup of transactions associated with an address.


### PR DESCRIPTION
Standardize path parameters to use {address} across EVM and SVM APIs. Replace URI with address where it referred to wallet/contract addresses.