### PR TITLE
Fix SVM Balances compute unit cost documentation

### DIFF
--- a/svm/balances.mdx
+++ b/svm/balances.mdx
@@ -17,4 +17,4 @@ The `next_offset` value is passed back by the initial response and can be used t
 
 ## Compute Unit Cost
 
-The SVM Balances endpoint has a fixed CU cost of **1** per request. See the [Compute Units](/compute-units) page for detailed information.
+The SVM Balances endpoint costs **1 CU per chain requested**. If no chains are specified, it defaults to Solana only (1 CU). See the [Compute Units](/compute-units) page for detailed information.


### PR DESCRIPTION
- Change from 'fixed CU cost of 1 per request' to '1 CU per chain requested'
- Add clarification that it defaults to Solana only (1 CU) when no chains specified
- Aligns with the compute-units.mdx documentation showing Balances as chain-dependent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update SVM Balances docs to state cost is 1 CU per chain requested, defaulting to Solana (1 CU) when unspecified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e4b67e59e5e51320e5a83663251346c9800bc34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->