### PR TITLE
Compute Units Documentation Clarification Updates

### DIFF
--- a/compute-units.mdx
+++ b/compute-units.mdx
@@ -4,21 +4,23 @@ sidebarTitle: "Compute Units"
 description: "Understand how Sim bills API usage using Compute Units (CUs) and how they're calculated per endpoint."
 ---
 
+import { DefaultChainCount } from "/snippets/default-chain-count.mdx";
+
 Compute Units (CUs) are how we measure API usage in Sim. CUs reflect the actual computational work of each API call. For example, querying Balances across 30 chains uses more CUs than querying just two chains.
 
-| Endpoint | Type | Compute Units |
-| --- | --- | --- |
-| Balances (EVM & SVM) | Chain-dependent | N compute units, where N is the number of chains processed in the `chain_ids` query parameter after tag expansion |
-| Balances (single token sub-path) | Fixed | 1 compute unit per request. Accepts exactly one `chain_ids` value (single chain only) |
-| Collectibles | Chain-dependent | N compute units, where N is the number of chains processed in the `chain_ids` query parameter after tag expansion |
-| Activity | Fixed | 3 compute units per request |
-| Transactions (EVM & SVM) | Fixed | 1 compute unit per request |
-| Token Info | Fixed | 2 compute units per request, even though `chain_ids` is required |
-| Token Holders | Fixed | 2 compute units per request |
+| Endpoint | Type | Compute Units | Default Chains (no chain_ids) |
+| --- | --- | --- | --- |
+| Balances (EVM & SVM) | Chain-dependent | N compute units, where N is the number of chains processed in the `chain_ids` query parameter after tag expansion | {<DefaultChainCount endpoint="balances" />} |
+| Balances (single token sub-path) | Fixed | 1 compute unit per request. Accepts exactly one `chain_ids` value (single chain only) | - |
+| Collectibles | Chain-dependent | N compute units, where N is the number of chains processed in the `chain_ids` query parameter after tag expansion | {<DefaultChainCount endpoint="collectibles" />} |
+| Activity | Fixed | 3 compute units per request | — |
+| Transactions (EVM & SVM) | Fixed | 1 compute unit per request | — |
+| Token Info | Fixed | 2 compute units per request, even though `chain_ids` is required | — |
+| Token Holders | Fixed | 2 compute units per request | — |
 
 ## How CUs work
 
-For chain-dependent endpoints, CU equals the number of distinct chains the request processes. If you pass tags (like `default`, `mainnet`, or `testnet`) via `chain_ids`, we expand them to specific chains before computing CU. If you omit `chain_ids` in the Collectibles or Balances endpoints, the endpoint uses its default chain set. The number of chains that are tagged by default is dependent on the number of chains and is subject to change as Sim APIs adds more chains. CU equals the size of that set at request time.
+For chain-dependent endpoints, CU equals the number of distinct chains the request processes. If you pass tags (like `default`, `mainnet`, or `testnet`) via `chain_ids`, we expand them to specific chains before computing CU. If you omit `chain_ids` in the Collectibles or Balances endpoints, the endpoint uses its default chain set. CU equals the size of that set at request time, currently {<DefaultChainCount endpoint="balances" />} for Balances and {<DefaultChainCount endpoint="collectibles" />} for Collectibles, and may change as Sim adds more chains.
 
 For fixed endpoints, each request consumes exactly specified number of compute units regardless of how many chains you query or what parameters you provide.
 
@@ -28,34 +30,31 @@ Chain count is computed after we expand any tags you pass. To keep CU predictabl
 
 ## Examples
 
-<Columns>
+<Columns cols={2}>
   <Card title="Balances: explicit chains">
     Use `?chain_ids=1,8453,137` to process three chains. This consumes three CUs.
   </Card>
-  <Card title="Balances: default set">
-    Omitting `chain_ids` uses the endpoint's chains tagged `default`. CU equals the size of that set at request time (approximately 25 and subject to change). See [Supported Chains](/evm/supported-chains#tags).
+<Card title="Balances: default set">
+    Omitting `chain_ids` uses the endpoint's chains tagged `default`. CU equals the size of that set at request time ({<DefaultChainCount endpoint="balances" />} as of now, and subject to change). See [Supported Chains](/evm/supported-chains#tags).
   </Card>
-</Columns>
 
-<Columns>
-  <Card title="Balances: mainnet tag">
+    <Card title="Balances: mainnet tag">
     Passing `?chain_ids=mainnet` expands to all supported mainnet chains for the endpoint. CU equals the expanded chain count.
   </Card>
   <Card title="Balances (single token sub-path): fixed cost">
     Each request consumes 1 CU and must specify exactly one chain via `chain_ids`.
   </Card>
-  <Card title="Collectibles: chain-dependent">
-    Collectibles follows the same chain-dependent model as Balances. Count your chains after tag expansion to estimate CU.
+  <Card title="Collectibles: default set">
+    Omitting `chain_ids` uses the endpoint's chains tagged `default`. CU equals the size of that set at request time ({<DefaultChainCount endpoint="collectibles" />} as of now, and subject to change).
   </Card>
-</Columns>
 
-<Columns>
-  <Card title="Activity: fixed cost">
+    <Card title="Activity: fixed cost">
     Activity uses a fixed-cost model. Each request consumes the same CU regardless of chains queried.
   </Card>
   <Card title="Token Info: fixed cost">
     Token Info is fixed-cost per request, even though `chain_ids` is required. CU does not scale with the number of chains.
   </Card>
+
 </Columns>
 
 ## FAQs

--- a/evm/balances.mdx
+++ b/evm/balances.mdx
@@ -5,6 +5,7 @@ openapi: "/evm/openapi/balances.json GET /v1/evm/balances/{address}"
 sidebarTitle: "Balances"
 ---
 
+import { DefaultChainCount } from "/snippets/default-chain-count.mdx";
 import { SupportedChains } from "/snippets/supported-chains.mdx";
 
 ![Balance Sv](/images/balance.svg)
@@ -31,7 +32,7 @@ The Balances endpoint’s CU cost equals the number of chains you include via th
 For example, `?chain_ids=1,8453,137` processes three chains and consumes three CUs.
 
 <Note>
-  If you omit `chain_ids`, the endpoint uses its `default` chain set (low-latency networks). CU equals the size of that set at request time and may change as defaults evolve. See the tags section of the <a href="/evm/supported-chains#tags">Supported Chains</a> page and the <a href="/compute-units">Compute Units</a> page for details.
+  If you omit `chain_ids`, the endpoint uses its `default` chain set (low-latency networks), which equals {<DefaultChainCount endpoint="balances" />} chains at request time (subject to change). See the tags section of the <a href="/evm/supported-chains#tags">Supported Chains</a> page and the <a href="/compute-units">Compute Units</a> page for details.
 </Note>
 
 ## Historical prices

--- a/evm/collectibles.mdx
+++ b/evm/collectibles.mdx
@@ -5,6 +5,7 @@ description: "Retrieve EVM compatiable NFTs (ERC721 and ERC1155) that include to
 openapi: "/evm/openapi/collectibles.json GET /v1/evm/collectibles/{address}"
 ---
 
+import { DefaultChainCount } from '/snippets/default-chain-count.mdx';
 import { SupportedChains } from '/snippets/supported-chains.mdx';
 
 ![Type=collectibles Web](/images/type=collectibles.webp)
@@ -15,9 +16,9 @@ The Collectibles API provides information about NFTs (ERC721 and ERC1155 tokens)
 
 ## Compute Unit Cost
 
-The Collectibles endpoint’s CU cost equals the number of chains you include via the `chain_ids` query parameter. If you omit `chain_ids`, we use the endpoint’s chains tagged `default`. See the [Supported Chains](/evm/supported-chains#tags) page to learn about chain tags.
+The Collectibles endpoint’s CU cost equals the number of chains you include via the `chain_ids` query parameter. If you omit `chain_ids`, we use the endpoint’s chains tagged `default` (currently {<DefaultChainCount endpoint="collectibles" />} chains, subject to change). See the [Supported Chains](/evm/supported-chains#tags) page to learn about chain tags.
 
-For example, `?chain_ids=1,8453,137` processes three chains and consumes three CUs. Omitting `chain_ids` uses the default set at request time and consumes a CU count equal to the size of that set.
+For example, `?chain_ids=1,8453,137` processes three chains and currently consumes three CUs. Omitting `chain_ids` uses the default set at request time and consumes {<DefaultChainCount endpoint="collectibles" />} CUs (equal to the size of that set).
 
 <Note>
 See the [Compute Units](/compute-units) page for detailed information.

--- a/evm/supported-chains.mdx
+++ b/evm/supported-chains.mdx
@@ -5,6 +5,7 @@ description: "Explore chains supported by Sim's EVM API endpoints."
 openapi: "/evm/openapi/supported-chains.json"
 ---
 
+import { DefaultChainCount } from '/snippets/default-chain-count.mdx';
 import { SupportedChainsAccordion } from '/snippets/supported-chains-accordion.mdx';
 
 <img src="/images/evm/Chains.svg" alt="Sim APIs Supported Chains" className="w-full mx-auto" />
@@ -13,14 +14,6 @@ The Supported Chains endpoint provides realtime information about which blockcha
 Chain support varies by API endpoint. Use the dropdown below to check which chains are available for each API:
 
 <SupportedChainsAccordion />
-
-## Using the API Endpoint
-
-You can programmatically retrieve the list of supported chains to adapt to newly supported networks.
-
-The response includes an array of supported chains.
-Each item in the array includes the chain's `name`, `chain_id`, an array of `tags`, and support for each endpoint.
-Each endpoint (balances, transactions, activity, etc.) has a `supported` boolean value
 
 <RequestExample>
 
@@ -138,7 +131,9 @@ Open the accordion above and scan the table to see which chains carry tags and w
 
 ## Compute Units
 
-Chain selection directly determines CU cost for chain-dependent endpoints (like Balances and Collectibles). CU equals the number of distinct chains included after expanding any tags you pass in `chain_ids`. If you omit `chain_ids`, we use the endpoint's default set. Your CU equals the size of that set at request time. To keep usage predictable over time, pin explicit chain IDs instead of tags.
+Chain selection directly determines CU cost for chain-dependent endpoints (like Balances and Collectibles). CU equals the number of distinct chains included after expanding any tags you pass in `chain_ids`.
+
+If you omit `chain_ids`, the endpoint uses its `default` chain set. That is currently {<DefaultChainCount endpoint="balances" />} chains for Balances and {<DefaultChainCount endpoint="collectibles" />} chains for Collectibles (these values can change over time).
 
 See [Compute Units](/compute-units) for the full rate card and guidance.
 
@@ -218,3 +213,11 @@ async function validateChainSupport(chainId, endpointName) {
 const result = await validateChainSupport(1, 'balances');
 console.log(result.message); // "Chain ethereum supports balances"
 ```
+
+## Using the API Endpoint
+
+You can programmatically retrieve the list of supported chains to adapt to newly supported networks.
+
+The response includes an array of supported chains.
+Each item in the array includes the chain's `name`, `chain_id`, an array of `tags`, and support for each endpoint.
+Each endpoint (balances, transactions, activity, etc.) has a `supported` boolean value

--- a/snippets/default-chain-count.mdx
+++ b/snippets/default-chain-count.mdx
@@ -1,0 +1,48 @@
+export const DefaultChainCount = ({ endpoint }) => {
+  const dataState = useState(null);
+  const data = dataState[0];
+  const setData = dataState[1];
+
+  useEffect(function() {
+    fetch("https://api.sim.dune.com/v1/evm/supported-chains", {
+      method: "GET",
+    })
+      .then(function(response) {
+        return response.json();
+      })
+      .then(function(responseData) {
+        setData(responseData);
+      });
+  }, []);
+
+  if (data === null) {
+    return <>N</>;
+  }
+
+  if (!data.chains || !Array.isArray(data.chains)) {
+    return <>N</>;
+  }
+
+  var uniqueDefaultChains = new Set();
+
+  for (var i = 0; i < data.chains.length; i++) {
+    var chain = data.chains[i];
+    var hasDefaultTag = Array.isArray(chain.tags) && chain.tags.indexOf("default") !== -1;
+    if (!hasDefaultTag) {
+      continue;
+    }
+
+    if (endpoint !== undefined) {
+      if (chain[endpoint] && chain[endpoint].supported === true) {
+        uniqueDefaultChains.add(chain.name);
+      }
+    } else {
+      uniqueDefaultChains.add(chain.name);
+    }
+  }
+
+  var count = uniqueDefaultChains.size;
+  return <>{count}</>;
+};
+
+

--- a/svm/balances.mdx
+++ b/svm/balances.mdx
@@ -17,4 +17,4 @@ The `next_offset` value is passed back by the initial response and can be used t
 
 ## Compute Unit Cost
 
-The SVM Balances endpoint costs **1 CU per chain requested**. If no chains are specified, it defaults to Solana only (1 CU). See the [Compute Units](/compute-units) page for detailed information.
+The SVM Balances endpoint’s CU cost equals the number of chains you include via the `chains` query parameter. If you omit `chains`, the endpoint uses its default chain set, which is currently Solana only (**1 CU**). We currently support two SVM chains (Solana and Eclipse). See the [Compute Units](/compute-units) page for detailed information.


### PR DESCRIPTION
Introduce DefaultChainCount snippet to compute live default chain counts per endpoint and integrate it into Compute Units (new column, cards), EVM Balances/Collectibles (CU copy/examples), and Supported Chains (CU section). Clarified SVM Balances CU wording (two chains; default Solana=1 CU) and made the snippet render “N” when data is unavailable.