### PR TITLE
Fixing a code sample that is using block.number instead of blockNumber()

### DIFF
--- a/idx/listener/features.mdx
+++ b/idx/listener/features.mdx
@@ -73,7 +73,7 @@ contract MyBlockListener is Raw$OnBlock {
     event BlockProcessed(uint256 blockNumber, uint256 timestamp);
 
     function onBlock(RawBlockContext memory /*ctx*/) external override {
-        emit BlockProcessed(block.number, block.timestamp);
+        emit BlockProcessed(blockNumber(), block.timestamp);
     }
 }
 ```


### PR DESCRIPTION
Fixing a code sample that is using block.number instead of blockNumber() on the listener page.