### PR TITLE
Clarifying how chain_ids works across all endpoints. 

### DIFF
--- a/evm/openapi/activity.json
+++ b/evm/openapi/activity.json
@@ -47,7 +47,7 @@
             "name": "chain_ids",
             "in": "query",
             "required": false,
-            "description": "Filter by chain(s). Accepts a single numeric chain ID (e.g. `?chain_ids=1`), a single chain name (e.g. `?chain_ids=ethereum`), or a comma separated list of either (e.g. `?chain_ids=1,137` or `?chain_ids=ethereum,polygon`). If omitted, results include activity from chains with the \"default\" tag for the address. See the [Supported Chains Tags](/evm/supported-chains#tags) section.",
+            "description": "Filter by chain(s). Accepts numeric chain IDs and/or tags. Provide a single value (e.g. `?chain_ids=1` or `?chain_ids=mainnet`) or a comma-separated list (e.g. `?chain_ids=1,8543,testnet`). Chain names are not accepted. If this query parameter is omitted, results include activity from chains with the `default` tag. See the [Supported Chains Tags](/evm/supported-chains#tags) section.",
             "schema": {
               "type": "string"
             }

--- a/evm/openapi/balances.json
+++ b/evm/openapi/balances.json
@@ -46,7 +46,7 @@
             "name": "chain_ids",
             "in": "query",
             "required": false,
-            "description": "Filter by chain(s). Accepts a single numeric chain ID (e.g. `?chain_ids=1`), a single chain name (e.g. `?chain_ids=ethereum`), or a comma separated list of either (e.g. `?chain_ids=1,137` or `?chain_ids=ethereum,polygon`). If omitted, results include collectibles from chains with the \"default\" tag for the address. See the [Supported Chains Tags](/evm/supported-chains#tags) section.",
+            "description": "Filter by chain(s). Accepts numeric chain IDs and/or tags. Provide a single value (e.g. `?chain_ids=1` or `?chain_ids=mainnet`) or a comma-separated list (e.g. `?chain_ids=1,8543,testnet`). Chain names are not accepted. If this query parameter is omitted, results include balances from chains with the `default` tag. See the [Supported Chains Tags](/evm/supported-chains#tags) section.",
             "schema": {
               "type": "string"
             }
@@ -222,7 +222,7 @@
             "name": "chain_ids",
             "in": "query",
             "required": true,
-            "description": "Specify exactly one numeric chain ID (e.g., `?chain_ids=1`). Comma-separated lists, chain names, and tags are not accepted for this sub-endpoint.",
+            "description": "Filter by chain(s). Accepts numeric chain IDs and/or tags. Provide a single value (e.g. `?chain_ids=1`) or a comma-separated list (e.g. `?chain_ids=1,8543,testnet`). Chain names are not accepted. If omitted, results include balances from chains with the \"default\" tag for the address. See the [Supported Chains Tags](/evm/supported-chains#tags) section.",
             "schema": { "type": "string" }
           },
           {

--- a/evm/openapi/collectibles.json
+++ b/evm/openapi/collectibles.json
@@ -199,7 +199,7 @@
             "name": "chain_ids",
             "in": "query",
             "required": false,
-            "description": "Filter by chain(s). Accepts a single numeric chain ID (e.g. `?chain_ids=1`), a single chain name (e.g. `?chain_ids=ethereum`), or a comma-separated list of either (e.g. `?chain_ids=1,137` or `?chain_ids=ethereum,polygon`). If omitted, results include collectibles from chains with the \"default\" tag for the address. See the [Supported Chains — Tags](/evm/supported-chains#tags) section.",
+            "description": "Filter by chain(s). Accepts numeric chain IDs and/or tags. Provide a single value (e.g. `?chain_ids=1` or `?chain_ids=mainnet`) or a comma-separated list (e.g. `?chain_ids=1,8543,testnet`). Chain names are not accepted. If this query parameter is omitted, results include collectibles from chains with the `default` tag. See the [Supported Chains Tags](/evm/supported-chains#tags) section.",
             "schema": {
               "type": "string"
             }

--- a/evm/openapi/token-holders.json
+++ b/evm/openapi/token-holders.json
@@ -123,7 +123,7 @@
             "name": "chain_id",
             "in": "path",
             "required": true,
-            "description": "The identifier of the blockchain (e.g., 8453 for Base). For a full list see Supported Chains.",
+            "description": "The chain id of the blockchain (e.g., 8453 for Base). For a full list see [Supported Chains](/evm/supported-chains).",
             "schema": {
               "type": "integer",
               "format": "int32",

--- a/evm/openapi/token-info.json
+++ b/evm/openapi/token-info.json
@@ -45,7 +45,7 @@
           {
             "name": "chain_ids",
             "in": "query",
-            "description": "Either 'all' or a comma separated list of chain ids to get token info for",
+            "description": "Specify exactly one chain. Accepts a single numeric chain ID (e.g. `?chain_ids=1`). Chain names are not accepted. See the [Supported Chains Tags](/evm/supported-chains#tags) section.",
             "required": true,
             "schema": {
               "type": "string",

--- a/evm/openapi/transactions.json
+++ b/evm/openapi/transactions.json
@@ -46,7 +46,7 @@
           {
             "name": "chain_ids",
             "in": "query",
-            "description": "Filter by chain(s). Accepts a single numeric chain ID (e.g. ?chain_ids=1), a single chain name (e.g. ?chain_ids=ethereum), or a comma separated list of either (e.g. ?chain_ids=1,137 or ?chain_ids=ethereum,polygon). If omitted, results include collectibles from chains with the \"default\" tag for the address. See the [Supported Chains Tags](/evm/supported-chains#tags) section.",
+            "description": "Filter by chain(s). Accepts numeric chain IDs and/or tags. Provide a single value (e.g. `?chain_ids=1` or `?chain_ids=mainnet`) or a comma-separated list (e.g. `?chain_ids=1,8543,testnet`). Chain names are not accepted. If this query parameter is omitted, results include transactions from chains with the `default` tag. See the [Supported Chains Tags](/evm/supported-chains#tags) section.",
             "required": false,
             "schema": {
               "type": "string"

--- a/evm/supported-chains.mdx
+++ b/evm/supported-chains.mdx
@@ -120,7 +120,8 @@ Any endpoint that supports the `chain_ids` query parameter accepts a tag in plac
 When using `chain_ids`, you can request chains in several ways:
 
 - **By tags**: `?chain_ids=mainnet` returns all chains tagged with `mainnet`. Using `?chain_ids=mainnet,testnet` returns all chains that are tagged with `mainnet` _or_ `testnet`.
-- **Specific chain IDs**: `?chain_ids=1,137,42161` (Ethereum, Polygon, Arbitrum)
+- **Specific chain IDs**: `?chain_ids=1,137,42161` (Ethereum, Polygon, Arbitrum).
+- **Mix tags and numeric IDs**: `?chain_ids=1,8543,testnet`
 - **Default behavior**: Omitting `chain_ids` returns only chains tagged `default`.
 
 Some supported chains have **no tag assigned**.
@@ -137,9 +138,17 @@ If you omit `chain_ids`, the endpoint uses its `default` chain set. That is curr
 
 See [Compute Units](/compute-units) for the full rate card and guidance.
 
+## Using the API Endpoint
+
+You can programmatically retrieve the list of supported chains to adapt to newly supported networks.
+
+The response includes an array of supported chains.
+Each item in the array includes the chain's `name`, `chain_id`, an array of `tags`, and support for each endpoint.
+Each endpoint (balances, transactions, activity, etc.) has a `supported` boolean value
+
 ## Examples
 
-Here are two practical examples of how you might use this endpoint:
+Here are two practical examples of how you might use the API endpoint:
 
 ### 1. Building a Dynamic Chain Selector
 
@@ -213,11 +222,3 @@ async function validateChainSupport(chainId, endpointName) {
 const result = await validateChainSupport(1, 'balances');
 console.log(result.message); // "Chain ethereum supports balances"
 ```
-
-## Using the API Endpoint
-
-You can programmatically retrieve the list of supported chains to adapt to newly supported networks.
-
-The response includes an array of supported chains.
-Each item in the array includes the chain's `name`, `chain_id`, an array of `tags`, and support for each endpoint.
-Each endpoint (balances, transactions, activity, etc.) has a `supported` boolean value

--- a/svm/openapi/balances.json
+++ b/svm/openapi/balances.json
@@ -46,7 +46,7 @@
           {
             "name": "chains",
             "in": "query",
-            "description": "Comma-separated list of chains to include. You can specify either solana or eclipse. For example, `?chains=solana,eclipse`.",
+            "description": "Comma-separated list of chains to include. You can specify either solana or eclipse. For example, `?chains=solana,eclipse`. If omitted, the endpoint will default to solana only.",
             "required": false,
             "schema": {
               "type": "string"

--- a/svm/transactions.mdx
+++ b/svm/transactions.mdx
@@ -5,7 +5,7 @@ openapi: '/svm/openapi/transactions.json GET /beta/svm/transactions/{address}'
 ---
 
 The Transactions Endpoint allows for quick and accurate lookup of transactions associated with an address.
-We currently only support Solana.
+**We currently only support Solana**.
 
 # Response Structure
 


### PR DESCRIPTION
Clarifying how chain_ids works across all endpoints. Also clarifying descriptions in the Supported Chains page. This description should be accurate (chain ids and tags only) and be much more clear for developers. Also, it adds appropriate chain id descriptions for activity and transactions endpoints.