### PR TITLE
Collectibles API Spam Filtering

### DIFF
--- a/evm/collectibles.mdx
+++ b/evm/collectibles.mdx
@@ -10,7 +10,7 @@ import { SupportedChains } from '/snippets/supported-chains.mdx';
 
 ![Type=collectibles Web](/images/type=collectibles.webp)
 
-The Collectibles API provides information about NFTs (ERC721 and ERC1155 tokens) owned by a specific address on supported EVM blockchains.
+The Collectibles API provides information about NFTs (ERC721 and ERC1155 tokens) owned by a specific address on supported EVM blockchains, with built-in spam filtering.
 
 <SupportedChains endpoint="collectibles" />
 
@@ -23,3 +23,29 @@ For example, `?chain_ids=1,8453,137` processes three chains and currently consum
 <Note>
 See the [Compute Units](/compute-units) page for detailed information.
 </Note>
+
+## Spam Filtering
+
+By default, spam filtering for collectibles is enabled. Use `filter_spam=false` to disable it. You can omit the parameter or set `filter_spam=true` to keep spam filtering enabled.
+
+We provide spam scores to explain how a collectible is classified as spam or not.
+Spam scores are _off_ by default. Enable them with `show_spam_scores=true`.
+Scores are computed as a weighted average across signals.
+These include whether Alchemy has flagged the collection, trade volume since launch, and the number of unique buyers and sellers.
+See the table below for the full list.
+
+<Accordion title="Spam Scoring Signals" icon="shield">
+
+| Feature | Description |
+| --- | --- |
+| `trade_volume` | This is the total number of trades since collection launch. Very low activity can indicate spam. Collections launched in the last 7 days are excluded from this signal. |
+| `unique_buyers` | This is the count of distinct buyers. Low buyer diversity can indicate inorganic activity. |
+| `unique_sellers` | This is the count of distinct sellers. Low seller diversity can indicate inorganic activity. |
+| `is_alchemy_flagged` | Whether the collection is flagged as spam by Alchemy. `true` increases the spam likelihood. |
+| `ipfs_uri_present` | This indicates whether token metadata URIs use IPFS. Certain patterns can correlate with spam when combined with other signals. |
+| `suspicious_words` | Whether names, symbols, or URIs include suspicious terms commonly associated with scams. |
+| `url_shortener_in_uri` | This indicates whether metadata URIs use link shorteners. For example, Bitly links can obscure destinations. |
+
+</Accordion>
+
+These spam score features are included in the response's `explanations` field and may be omitted if signals are unavailable.

--- a/evm/openapi/collectibles.json
+++ b/evm/openapi/collectibles.json
@@ -112,6 +112,61 @@
             "type": "string",
             "format": "date-time",
             "description": "Timestamp of when this token ID was last acquired by the address."
+          },
+          "is_spam": {
+            "type": "boolean",
+            "description": "Whether the collection is classified as spam."
+          },
+          "spam_score": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "0–100 confidence score that the collection is spam. Included only when `show_spam_scores=true`. May be omitted when scores are unavailable. See the [Spam Filtering](#spam-filtering) section for more details."
+          },
+          "explanations": {
+            "type": "array",
+            "description": "Signals contributing to the spam score. Included only when `show_spam_scores=true`. May be omitted when scores are unavailable.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "feature": {
+                  "type": "string",
+                  "description": "Signal used in scoring.",
+                  "enum": [
+                    "trade_volume",
+                    "unique_buyers",
+                    "unique_sellers",
+                    "is_alchemy_flagged",
+                    "ipfs_uri_present",
+                    "suspicious_words",
+                    "url_shortener_in_uri"
+                  ]
+                },
+                "value": {
+                  "description": "Observed value for the feature (type varies by feature).",
+                  "oneOf": [
+                    { "type": "integer", "format": "int32" },
+                    { "type": "boolean" }
+                  ]
+                },
+                "feature_score": {
+                  "type": "integer",
+                  "format": "int32",
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "0–100 contribution of this feature to the spam score."
+                },
+                "feature_weight": {
+                  "type": "number",
+                  "format": "float",
+                  "minimum": 0,
+                  "maximum": 1,
+                  "description": "Weight applied to this feature in the weighted average."
+                }
+              },
+              "required": ["feature"]
+            }
           }
         },
         "required": [
@@ -121,7 +176,8 @@
           "chain",
           "chain_id",
           "balance",
-          "last_acquired"
+          "last_acquired",
+          "is_spam"
         ]
       },
       "CollectiblesResponse": {
@@ -225,6 +281,26 @@
               "maximum": 2500,
               "default": 250
             }
+          },
+          {
+            "name": "filter_spam",
+            "in": "query",
+            "required": false,
+            "description": "When true, hide collectibles identified as spam. Set to false to return all collectibles, including potential spam. See the [Spam Filtering](##spam-filtering) section for more details.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "show_spam_scores",
+            "in": "query",
+            "required": false,
+            "description": "When true, include spam scoring details including contributing signals to explain filtering decisions.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
@@ -258,6 +334,14 @@
                               { "key": "Stance", "value": "Greased" }
                             ]
                           },
+                        "is_spam": false,
+                        "spam_score": 0,
+                        "explanations": [
+                          { "feature": "trade_volume", "value": 518, "feature_score": 0, "feature_weight": 0.25 },
+                          { "feature": "unique_buyers", "value": 145, "feature_score": 0, "feature_weight": 0.25 },
+                          { "feature": "unique_sellers", "value": 167, "feature_score": 0, "feature_weight": 0.25 },
+                          { "feature": "is_alchemy_flagged", "value": false, "feature_score": 0, "feature_weight": 0.25 }
+                        ],
                           "balance": "8",
                           "last_acquired": "2025-08-10T03:58:59Z"
                         },


### PR DESCRIPTION
Adding the required documentation for Ilias' Spam Filtering implementation for the Collectibles API endpoint. Cleaning up some explanations and making sure everything is on point in the openapi and in the mdx file.