### PR TITLE
Docs: DeFi positions endpoint

### DIFF
--- a/compute-units.mdx
+++ b/compute-units.mdx
@@ -13,6 +13,7 @@ Compute Units (CUs) are how we measure API usage in Sim. CUs reflect the actual 
 | Balances (EVM & SVM) | Chain-dependent | N compute units, where N is the number of chains processed in the `chain_ids` query parameter after tag expansion | {<DefaultChainCount endpoint="balances" />} |
 | Balances (single token sub-path) | Fixed | 1 compute unit per request. Accepts exactly one `chain_ids` value (single chain only) | - |
 | Collectibles | Chain-dependent | N compute units, where N is the number of chains processed in the `chain_ids` query parameter after tag expansion | {<DefaultChainCount endpoint="collectibles" />} |
+| DeFi Positions | Chain-dependent | 2N compute units, where N is the number of chains processed in the `chain_ids` query parameter after tag expansion | — |
 | Activity | Fixed | 3 compute units per request | — |
 | Transactions (EVM & SVM) | Fixed | 1 compute unit per request | — |
 | Token Info | Fixed | 2 compute units per request, even though `chain_ids` is required | — |

--- a/docs.json
+++ b/docs.json
@@ -43,6 +43,7 @@
               "evm/balances",
               "evm/activity",
               "evm/collectibles",
+              "evm/defi-positions",
               "evm/transactions",
               "evm/token-info",
               "evm/token-holders"
@@ -168,6 +169,10 @@
     {
       "name": "EVM Token Holders",
       "file": "evm/openapi/token-holders.json"
+    },
+    {
+      "name": "EVM DeFi Positions",
+      "file": "evm/openapi/defi-positions.json"
     },
     {
       "name": "EVM Supported Chains",

--- a/evm/defi-positions.mdx
+++ b/evm/defi-positions.mdx
@@ -1,0 +1,132 @@
+---
+title: "DeFi Positions"
+description: "Access a wallet's DeFi positions along with USD values and metadata across supported EVM chains."
+openapi: "/evm/openapi/defi-positions.json GET /beta/evm/defi/positions/{address}"
+sidebarTitle: "DeFi Positions"
+---
+
+The DeFi Positions endpoint consolidates lending, borrowing, liquidity, yield, and staking exposures for a wallet. Use it to power portfolio dashboards, risk monitoring, and customer reporting without stitching together protocol-specific datasets.
+
+> **Preview:** This endpoint is currently available at the beta path (`/beta/evm/defi/positions`). Schemas are stable, but response fields may expand as we onboard new protocols.
+
+## Supported Coverage
+
+- **Liquidity:** Uniswap V2/V3/V4, Algebra v3 forks, iZUMi Swap, and additional AMMs rolling out regularly
+- **Lending:** Aave v2/v3 (supply, variable debt), Compound v2/v3, and Moonwell markets
+- **Yield:** Pendle v2, ERC-4626 vaults (Yearn v3, Pendle Yield PTs, and compatible vaults)
+- **Tokenized positions:** Protocol share tokens such as aTokens, cTokens, ERC-4626 vault receipts
+- **NFT-based liquidity:** Concentrated liquidity NFTs (Uniswap v3 and compatible implementations)
+
+### Supported Chains
+
+We currently cover DeFi Positions on the following networks, with more chains on the roadmap:
+
+- Arbitrum
+- Base
+- Base Sepolia
+- BOB
+- Ethereum
+- Ink
+- Mode
+- Optimism
+- Shape
+- Soneium
+- Unichain
+- World
+- Zora
+
+## Request Parameters
+
+- `chain_ids` — Optional chain filter accepting numeric IDs or supported tags. When omitted, we return all chains tagged as `default`.
+- `protocol` — Filter to a specific protocol or category (`aave-v3`, `uniswap-v3`, `erc4626`, etc.).
+
+All requests require the `X-Sim-Api-Key` header with a Sim API key.
+
+## Response Structure
+
+Each response includes the queried wallet, timestamps, an array of positions, and aggregation totals.
+
+- `positions[]` items surface consistent metadata across protocols:
+  - **Protocol identifiers:** `protocol_name`, `protocol_id`, and protocol-defined `label`
+  - **Location:** `chain_id` and `contract_address`
+  - **Valuation:** `amount`, `usd_value`, and `unclaimed_usd_value`
+  - **details:** Protocol-specific fields such as token breakdowns, APYs, collateral flags, NFT ticks, or reward inventories. The shape of this object varies by integration and expands over time.
+
+- `aggregations.total_usd_value` sums the USD value of all returned positions.
+- `aggregations.total_by_chain` breaks down USD value per chain ID.
+
+### Sample Response
+
+```json
+{
+  "wallet_address": "0xcB1CBA32a4f9986B7981D6948e8fE2dF5B0c9905",
+  "request_time": "2025-03-06T18:12:29Z",
+  "response_time": "2025-03-06T18:12:29Z",
+  "positions": [
+    {
+      "protocol_name": "Compound v2",
+      "protocol_id": "compound-v2",
+      "label": "lend",
+      "chain_id": 1,
+      "name": "Compound DAI Lending",
+      "contract_address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
+      "amount": 250,
+      "usd_value": 250.0,
+      "unclaimed_usd_value": 5.12,
+      "details": {
+        "underlying_token": {
+          "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+          "symbol": "DAI",
+          "decimals": 18
+        },
+        "supply_apy": 2.1,
+        "collateral_enabled": true
+      }
+    },
+    {
+      "protocol_name": "Uniswap v3",
+      "protocol_id": "uniswap-v3",
+      "label": "liquidity",
+      "chain_id": 1,
+      "name": "Uniswap V3 Position (WETH, USDC)",
+      "contract_address": "0xc36442b4a4522e871399cd717abdd847ab11fe88",
+      "amount": 1.2345,
+      "usd_value": 1234.5,
+      "unclaimed_usd_value": 10.45,
+      "details": {
+        "token0": {
+          "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+          "symbol": "WETH",
+          "amount": 0.52
+        },
+        "token1": {
+          "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          "symbol": "USDC",
+          "amount": 820.12
+        },
+        "token_id": 123456,
+        "tick_lower": -887220,
+        "tick_upper": -276330,
+        "share_of_pool": 0.0000125
+      }
+    }
+  ],
+  "aggregations": {
+    "total_usd_value": 1484.5,
+    "total_by_chain": {
+      "1": 1484.5
+    }
+  }
+}
+```
+
+### Compute Units
+
+Each request consumes two Compute Units per processed chain ID. Filtering to fewer chains lowers usage. Aggregations are calculated server-side and included in the same response.
+
+### Errors
+
+- `400 Bad Request` — Invalid address, malformed cursor, or unsupported parameter value
+- `404 Not Found` — No positions found for the wallet on the requested chains
+- `500 Internal Server Error` — Retryable server-side failure
+

--- a/evm/openapi/defi-positions.json
+++ b/evm/openapi/defi-positions.json
@@ -1,0 +1,276 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Sim API - DeFi Positions Endpoint",
+    "description": "Retrieve DeFi positions along with pricing and metadata for an address across supported EVM chains.",
+    "license": {
+      "name": ""
+    },
+    "version": "0.1.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.sim.dune.com"
+    }
+  ],
+  "paths": {
+    "/beta/evm/defi/positions/{address}": {
+      "get": {
+        "tags": [
+          "defi-positions"
+        ],
+        "summary": "Get DeFi positions for an address",
+        "description": "Returns a wallet's DeFi positions including protocol metadata, USD values, pending rewards, and aggregation summaries.",
+        "operationId": "getEvmDefiPositions",
+        "parameters": [
+          {
+            "name": "X-Sim-Api-Key",
+            "in": "header",
+            "description": "Used for authenticating requests. See [Authentication](/#authentication).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "address",
+            "in": "path",
+            "description": "Wallet address to inspect for DeFi positions.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^0x[a-fA-F0-9]{40}$"
+            },
+            "example": "0x9512044bc14267a6c588296a20bd7c00e0de7da3"
+          },
+          {
+            "name": "chain_ids",
+            "in": "query",
+            "required": false,
+            "description": "Filter by chain(s). Accepts numeric chain IDs and/or tags. Provide a single value (e.g. `?chain_ids=1` or `?chain_ids=mainnet`) or a comma-separated list (e.g. `?chain_ids=1,8453`). If omitted, positions are returned for chains with the `default` tag. See the [Supported Chains Tags](/evm/supported-chains#tags) section.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "protocol",
+            "in": "query",
+            "required": false,
+            "description": "Filter to a specific protocol or category (for example, `aave-v3`, `uniswap-v3`, or `erc4626`).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DefiPositionsResponse"
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "wallet_address": "0x9512044bc14267a6c588296a20bd7c00e0de7da3",
+                      "request_time": "2025-03-06T18:12:29.000Z",
+                      "response_time": "2025-03-06T18:12:29.000Z",
+                      "positions": [
+                        {
+                          "protocol_name": "Compound v2",
+                          "protocol_id": "compound-v2",
+                          "label": "lend",
+                          "chain_id": 1,
+                          "name": "Compound DAI Lending",
+                          "contract_address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
+                          "amount": 250,
+                          "usd_value": 250.0,
+                          "unclaimed_usd_value": 5.12,
+                          "details": {
+                            "underlying_token": {
+                              "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                              "symbol": "DAI",
+                              "decimals": 18
+                            },
+                            "supply_apy": 2.1,
+                            "collateral_enabled": true
+                          }
+                        },
+                        {
+                          "protocol_name": "Uniswap v3",
+                          "protocol_id": "uniswap-v3",
+                          "label": "liquidity",
+                          "chain_id": 1,
+                          "name": "Uniswap V3 Position (WETH, USDC)",
+                          "contract_address": "0xc36442b4a4522e871399cd717abdd847ab11fe88",
+                          "amount": 1.2345,
+                          "usd_value": 1234.5,
+                          "unclaimed_usd_value": 10.45,
+                          "details": {
+                            "token0": {
+                              "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                              "symbol": "WETH",
+                              "amount": 0.52
+                            },
+                            "token1": {
+                              "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                              "symbol": "USDC",
+                              "amount": 820.12
+                            },
+                            "token_id": 123456,
+                            "tick_lower": -887220,
+                            "tick_upper": -276330,
+                            "share_of_pool": 0.0000125
+                          }
+                        }
+                      ],
+                      "aggregations": {
+                        "total_usd_value": 1484.5,
+                        "total_by_chain": {
+                          "1": 1484.5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "404": {
+            "description": "Address not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DefiPosition": {
+        "type": "object",
+        "required": [
+          "protocol_name",
+          "protocol_id",
+          "chain_id",
+          "name",
+          "usd_value"
+        ],
+        "properties": {
+          "protocol_name": {
+            "type": "string",
+            "description": "Display name of the protocol (e.g. Uniswap v3, Aave v3)."
+          },
+          "protocol_id": {
+            "type": "string",
+            "description": "Slugified protocol identifier that remains stable across releases."
+          },
+          "label": {
+            "type": "string",
+            "description": "Protocol-specific label for the position (for example, lend, borrow, liquidity, vault)."
+          },
+          "chain_id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Numeric chain identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the position."
+          },
+          "contract_address": {
+            "type": "string",
+            "description": "Primary contract address associated with the position, such as the market, vault, or pool contract."
+          },
+          "amount": {
+            "type": "number",
+            "format": "double",
+            "description": "Quantity of the position, adjusted for token decimals."
+          },
+          "usd_value": {
+            "type": "number",
+            "format": "double",
+            "description": "USD value of the position."
+          },
+          "unclaimed_usd_value": {
+            "type": "number",
+            "format": "double",
+            "nullable": true,
+            "description": "USD value of unclaimed rewards or accrued yield for the position, when applicable."
+          },
+          "details": {
+            "type": "object",
+            "description": "Protocol-specific metadata. Field presence varies by protocol and position type.",
+            "additionalProperties": true
+          }
+        }
+      },
+      "DefiAggregations": {
+        "type": "object",
+        "properties": {
+          "total_usd_value": {
+            "type": "number",
+            "format": "double",
+            "description": "Sum of the USD value across all returned positions."
+          },
+          "total_by_chain": {
+            "type": "object",
+            "description": "Breakdown of USD value by chain, keyed by chain ID as a string.",
+            "additionalProperties": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        }
+      },
+      "DefiPositionsResponse": {
+        "type": "object",
+        "required": [
+          "wallet_address",
+          "positions"
+        ],
+        "properties": {
+          "wallet_address": {
+            "type": "string",
+            "description": "The wallet address that was queried."
+          },
+          "request_time": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the request was received."
+          },
+          "response_time": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the response was generated."
+          },
+          "positions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DefiPosition"
+            }
+          },
+          "aggregations": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DefiAggregations"
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "defi-positions",
+      "description": "DeFi Positions API"
+    }
+  ]
+}
+


### PR DESCRIPTION
Resolves API-3377

## Summary
- add OpenAPI spec for 
- publish endpoint guide and compute unit updates
- document supported chains and navigation entry

## Testing
- 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds EVM DeFi Positions endpoint docs and OpenAPI, wires it into navigation, and updates compute units to 2N per chain.
> 
> - **EVM DeFi Positions endpoint**:
>   - Add new docs page `evm/defi-positions.mdx` (beta) with coverage, params, sample response, aggregations, compute units, and errors.
>   - Introduce OpenAPI spec `evm/openapi/defi-positions.json` and register it in `docs.json` under OpenAPI specs.
>   - Update navigation in `docs.json` to include `evm/defi-positions` in EVM pages.
> - **Compute Units**:
>   - Update `compute-units.mdx` to add `DeFi Positions` as chain-dependent costing `2N` CUs per processed chain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb9752f23df154f480ae4c609a4abd0c2abb60b4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->