### PR TITLE
Update docs to remove alchemy references

### DIFF
--- a/evm/collectibles.mdx
+++ b/evm/collectibles.mdx
@@ -31,7 +31,7 @@ By default, spam filtering for collectibles is enabled. Use `filter_spam=false` 
 We provide spam scores to explain how a collectible is classified as spam or not.
 Spam scores are _off_ by default. Enable them with `show_spam_scores=true`.
 Scores are computed as a weighted average across signals.
-These include whether Alchemy has flagged the collection, trade volume since launch, and the number of unique buyers and sellers.
+These include whether the collection has been flagged by external providers, trade volume since launch, and the number of unique buyers and sellers.
 See the table below for the full list.
 
 <Accordion title="Spam Scoring Signals" icon="shield">
@@ -41,7 +41,7 @@ See the table below for the full list.
 | `trade_volume` | This is the total number of trades since collection launch. Very low activity can indicate spam. Collections launched in the last 7 days are excluded from this signal. |
 | `unique_buyers` | This is the count of distinct buyers. Low buyer diversity can indicate inorganic activity. |
 | `unique_sellers` | This is the count of distinct sellers. Low seller diversity can indicate inorganic activity. |
-| `is_alchemy_flagged` | Whether the collection is flagged as spam by Alchemy. `true` increases the spam likelihood. |
+| `externally_flagged` | Whether the collection has been flagged as spam by third-party providers. `true` increases the spam likelihood. |
 | `ipfs_uri_present` | This indicates whether token metadata URIs use IPFS. Certain patterns can correlate with spam when combined with other signals. |
 | `suspicious_words` | Whether names, symbols, or URIs include suspicious terms commonly associated with scams. |
 | `url_shortener_in_uri` | This indicates whether metadata URIs use link shorteners. For example, Bitly links can obscure destinations. |

--- a/evm/openapi/collectibles.json
+++ b/evm/openapi/collectibles.json
@@ -137,7 +137,7 @@
                     "trade_volume",
                     "unique_buyers",
                     "unique_sellers",
-                    "is_alchemy_flagged",
+                    "externally_flagged",
                     "ipfs_uri_present",
                     "suspicious_words",
                     "url_shortener_in_uri"
@@ -340,7 +340,7 @@
                           { "feature": "trade_volume", "value": 518, "feature_score": 0, "feature_weight": 0.25 },
                           { "feature": "unique_buyers", "value": 145, "feature_score": 0, "feature_weight": 0.25 },
                           { "feature": "unique_sellers", "value": 167, "feature_score": 0, "feature_weight": 0.25 },
-                          { "feature": "is_alchemy_flagged", "value": false, "feature_score": 0, "feature_weight": 0.25 }
+                          { "feature": "externally_flagged", "value": false, "feature_score": 0, "feature_weight": 0.25 }
                         ],
                           "balance": "8",
                           "last_acquired": "2025-08-10T03:58:59Z"


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-1823c007-7fa9-4a3d-a010-520e658765a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1823c007-7fa9-4a3d-a010-520e658765a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rename the spam signal from Alchemy-specific (`is_alchemy_flagged`) to generic `externally_flagged` and update docs/OpenAPI accordingly.
> 
> - **Docs (EVM Collectibles)**:
>   - Replace `is_alchemy_flagged` with `externally_flagged` in spam scoring signals and update descriptions to reference third‑party providers.
>   - Update narrative text to reflect external provider flagging.
> - **OpenAPI (collectibles.json)**:
>   - Change `explanations[].feature` enum value from `is_alchemy_flagged` to `externally_flagged`.
>   - Update example response to use `externally_flagged` in `explanations`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a92a082c921e5753fc9a66fd64f59026c87cff5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->