### PR TITLE
Fix documentation for token endpoint compatibility

### DIFF
--- a/evm/build-a-realtime-chat-agent.mdx
+++ b/evm/build-a-realtime-chat-agent.mdx
@@ -763,7 +763,7 @@ const functions = [
         type: "function",
         function: {
             name: "get_token_holders",
-            description: "Get token holders for a specific ERC20 token, ranked by wallet value.",
+            description: "Get token holders for a specific ERC20 token, ranked by balance descending.",
             parameters: {
                 type: "object",
                 properties: {

--- a/evm/overview.mdx
+++ b/evm/overview.mdx
@@ -43,6 +43,6 @@ sidebarTitle: "Overview"
     title="Token Holders"
     href="/evm/token-holders"
   >
-    Discover token distribution across ERC20 token holders, ranked by wallet value.
+    Discover token distribution across ERC20 token holders, ranked by balance descending.
   </Card>
 </CardGroup>

--- a/evm/token-holders.mdx
+++ b/evm/token-holders.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Token Holders"
 sidebarTitle: "Token Holders"
-description: "Discover token distribution across ERC20 token holders, ranked by wallet value."
+description: "Discover token distribution across ERC20 token holders, ranked by balance descending."
 openapi: "/evm/openapi/token-holders.json GET /v1/evm/token-holders/{chain_id}/{address}"
 ---
 


### PR DESCRIPTION
Corrected documentation for the token holders endpoint to specify it only works for ERC20 tokens.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C0766JKCP89/p1763067883938659?thread_ts=1763067883.938659&cid=C0766JKCP89)

<a href="https://cursor.com/background-agent?bcId=bc-05058f9e-d2ec-4dcb-bb36-d1f5e99ea041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-05058f9e-d2ec-4dcb-bb36-d1f5e99ea041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update EVM docs to state Token Holders supports ERC20 only and results are ranked by balance descending.
> 
> - **Docs updates (EVM)**
>   - `evm/token-holders.mdx`: Specify ERC20-only support; adjust description/body to “ranked by balance descending.”
>   - `evm/overview.mdx`: Update “Token Holders” card text to ERC20-only and balance-desc ranking.
>   - `evm/build-a-realtime-chat-agent.mdx`: Update `get_token_holders` tool description to ERC20-only and balance-desc ranking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd1262d80061d565bab7f4a00be9c724ed7ce803. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->