### PR TITLE
Subscriptions API `default_chains` update 

### DIFF
--- a/compute-units.mdx
+++ b/compute-units.mdx
@@ -18,7 +18,7 @@ Compute Units (CUs) are how we measure API usage in Sim. CUs reflect the actual 
 | Transactions (EVM & SVM) | Fixed | 1 compute unit per request | — |
 | Token Info | Fixed | 2 compute units per request, even though `chain_ids` is required | — |
 | Token Holders | Fixed | 2 compute units per request | — |
-| Subscriptions | Event-based | 1 compute unit per event sent to your webhook. Note that a single webhook payload can contain multiple events. | — |
+| Subscriptions | Event-based | 1 compute unit per event sent to your webhook. Note that a single webhook payload can contain multiple events. | All supported EVM chains (varies by subscription type) when chain_ids is omitted |
 
 ## How CUs work
 

--- a/evm/subscriptions.mdx
+++ b/evm/subscriptions.mdx
@@ -39,6 +39,8 @@ You can set up and manage your subscriptions in two ways:
 
 The Subscriptions API costs **1 CU per event** sent to your webhook. Note that a single webhook call may include multiple events. For example, multiple balance changes or transactions.
 
+If you omit `chain_ids` when creating a webhook your subscription watches all supported EVM chains for matching events. You are only charged per event received regardless of how many chains are monitored.
+
 Creating and managing webhook subscriptions through the API does not consume compute units. However, your account must have an active plan to use the Subscriptions API.
 
 <Note>


### PR DESCRIPTION
Making it more clear on the Subscriptions Overview and the Compute Units page how the ?chain_ids query parameter affects things if it's committed.