### PR TITLE
Update defi positions docs for Arbitrum

### DIFF
--- a/evm/defi-positions.mdx
+++ b/evm/defi-positions.mdx
@@ -17,7 +17,6 @@ Each position includes token holdings, USD valuations, underlying asset metadata
 <Note>
 This endpoint is currently available at the beta path (`/beta/evm/defi/positions`).
 Schemas are stable, but response fields may expand as we onboard new protocols.
-Also, **Arbitrum support is not currently available but is coming soon**.
 </Note>
 
 ## Supported Protocols


### PR DESCRIPTION
Remove the note stating Arbitrum is not supported for the DeFi positions endpoint, as Arbitrum is now supported.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C0766JKCP89/p1762780884762239?thread_ts=1762780884.762239&cid=C0766JKCP89)

<a href="https://cursor.com/background-agent?bcId=bc-49b6e8df-21c2-4e72-8cf9-f59775a95968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49b6e8df-21c2-4e72-8cf9-f59775a95968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the outdated note in `evm/defi-positions.mdx` that Arbitrum is not supported for the DeFi Positions endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 947a806c159d86ac647696fa0a535c37f05d7527. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->