### PR TITLE
Remove idx from docs navigation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -79,6 +79,10 @@ a.link:not(.nav-tabs-item){
 .nav-tabs,
 div:has(> .nav-tabs),
 #sidebar-content .sticky,
-#navigation-items button[type="button"] {
+#navigation-items button[type="button"] /* Hide it on mobile */ {
     display: none !important;
+}
+
+#table-of-contents {
+    padding-top: 0 !important;
 }


### PR DESCRIPTION
Remove the "Sim IDX" navigation tab from `docs.json`.

This change prevents new users from naturally discovering IDX through the documentation navigation, aligning with the "Kill IDX" project's goal, while ensuring existing IDX documentation remains accessible via direct URLs.

---
Linear Issue: [IDX-1190](https://linear.app/dune/issue/IDX-1190/remove-idx-from-nav-in-docs)

<a href="https://cursor.com/background-agent?bcId=bc-10f05b0c-e7d0-4737-9104-1a5d959ac8e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-10f05b0c-e7d0-4737-9104-1a5d959ac8e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the "Sim IDX" tab and all its groups from `docs.json` navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3562891175113972ebef7ff1ea83fa3c00ab29a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->