### PR TITLE
Subscriptions API Compute Unit Cost Update

### DIFF
--- a/compute-units.mdx
+++ b/compute-units.mdx
@@ -18,7 +18,7 @@ Compute Units (CUs) are how we measure API usage in Sim. CUs reflect the actual 
 | Transactions (EVM & SVM) | Fixed | 1 compute unit per request | — |
 | Token Info | Fixed | 2 compute units per request, even though `chain_ids` is required | — |
 | Token Holders | Fixed | 2 compute units per request | — |
-| Subscriptions | Event-based | 1 compute unit per event sent to your webhook. Note that a single webhook payload can contain multiple events. | All supported EVM chains (varies by subscription type) when chain_ids is omitted |
+| Subscriptions | Event-based | 2 compute units per event sent to your webhook. Note that a single webhook payload can contain multiple events. | All supported EVM chains (varies by subscription type) when chain_ids is omitted |
 
 ## How CUs work
 
@@ -57,7 +57,7 @@ Chain count is computed after we expand any tags you pass. To keep CU predictabl
     Token Info is fixed-cost per request, even though `chain_ids` is required. CU does not scale with the number of chains.
   </Card>
   <Card title="Subscriptions: event-based cost">
-    Each event sent to your webhook consumes 1 CU. A single webhook payload may contain multiple events, resulting in multiple CUs per webhook delivery.
+    Each event sent to your webhook consumes 2 CUs. A single webhook payload may contain multiple events, resulting in multiple CUs per webhook delivery.
   </Card>
 
 </Columns>

--- a/evm/subscriptions.mdx
+++ b/evm/subscriptions.mdx
@@ -37,7 +37,7 @@ You can set up and manage your subscriptions in two ways:
 
 ## Compute Unit Cost
 
-The Subscriptions API costs **1 CU per event** sent to your webhook. Note that a single webhook call may include multiple events. For example, multiple balance changes or transactions.
+The Subscriptions API costs **2 CUs per event** sent to your webhook. Note that a single webhook call may include multiple events. For example, multiple balance changes or transactions.
 
 If you omit `chain_ids` when creating a webhook your subscription watches all supported EVM chains for matching events. You are only charged per event received regardless of how many chains are monitored.
 


### PR DESCRIPTION
Updating the compute units for evm subscriptions to 2 compute units per event.