### PR TITLE
Remove Arbitrum from supported chains

### DIFF
--- a/snippets/supported-chains-accordion.mdx
+++ b/snippets/supported-chains-accordion.mdx
@@ -62,7 +62,12 @@ export const SupportedChainsAccordion = () => {
 
             var defiPositionsCount = 0;
             if (idxResponseData && idxResponseData.chains) {
-              defiPositionsCount = idxResponseData.chains.length;
+              // Count chains excluding Arbitrum (chain_id 42161)
+              for (var j = 0; j < idxResponseData.chains.length; j++) {
+                if (idxResponseData.chains[j].chain_id !== 42161) {
+                  defiPositionsCount++;
+                }
+              }
             }
 
             setCounts({
@@ -86,7 +91,13 @@ export const SupportedChainsAccordion = () => {
       if (!idxData || !idxData.chains) {
         return <p>No data available</p>;
       }
-      supportedChains = idxData.chains;
+      // Filter out Arbitrum (chain_id 42161) for defi_positions
+      for (var i = 0; i < idxData.chains.length; i++) {
+        var chain = idxData.chains[i];
+        if (chain.chain_id !== 42161) {
+          supportedChains.push(chain);
+        }
+      }
     } else {
       if (!data || !data.chains) {
         return <p>No data available</p>;

--- a/snippets/supported-chains.mdx
+++ b/snippets/supported-chains.mdx
@@ -39,7 +39,14 @@ export const SupportedChains = ({ endpoint, title }) => {
       }
     }
   } else {
-    supportedChains = data.chains;
+    // For defi_positions, filter out Arbitrum
+    for (var i = 0; i < data.chains.length; i++) {
+      var chain = data.chains[i];
+      if (endpoint === 'defi_positions' && chain.chain_id === 42161) {
+        continue; // Skip Arbitrum
+      }
+      supportedChains.push(chain);
+    }
   }
 
   var count = supportedChains.length;


### PR DESCRIPTION
Remove Arbitrum from the DeFi Positions supported chains list in the documentation by filtering it out on the frontend.

The backend API still returns Arbitrum for this endpoint, so the documentation now explicitly filters it out to reflect the desired state for users. This ensures the displayed list and count are accurate without Arbitrum.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C0766JKCP89/p1765032294343009?thread_ts=1765032294.343009&cid=C0766JKCP89)

<a href="https://cursor.com/background-agent?bcId=bc-0c6fab16-f9a9-40f4-a561-bb49479ba37c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c6fab16-f9a9-40f4-a561-bb49479ba37c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

