### PR TITLE
Remove arbitrum from api

### DIFF
--- a/snippets/supported-chains-accordion.mdx
+++ b/snippets/supported-chains-accordion.mdx
@@ -39,7 +39,8 @@ export const SupportedChainsAccordion = () => {
           if (chain.collectibles && chain.collectibles.supported) collectiblesCount++;
           if (chain.transactions && chain.transactions.supported) transactionsCount++;
           if (chain.token_info && chain.token_info.supported) tokenInfoCount++;
-          if (chain.token_holders && chain.token_holders.supported) tokenHoldersCount++;
+          // Exclude Arbitrum chains (42161, 42170) from Token Holders count as they're not actually supported
+          if (chain.token_holders && chain.token_holders.supported && chain.chain_id !== 42161 && chain.chain_id !== 42170) tokenHoldersCount++;
         }
 
         setCounts({
@@ -94,6 +95,11 @@ export const SupportedChainsAccordion = () => {
       for (var i = 0; i < data.chains.length; i++) {
         var chain = data.chains[i];
         if (chain[endpoint] && chain[endpoint].supported) {
+          // Temporary filter: Remove Arbitrum chains from Token Holders API
+          // These chains are not actually supported despite what the API returns
+          if (endpoint === "token_holders" && (chain.chain_id === 42161 || chain.chain_id === 42170)) {
+            continue;
+          }
           supportedChains.push(chain);
         }
       }

--- a/snippets/supported-chains.mdx
+++ b/snippets/supported-chains.mdx
@@ -35,6 +35,11 @@ export const SupportedChains = ({ endpoint, title }) => {
     for (var i = 0; i < data.chains.length; i++) {
       var chain = data.chains[i];
       if (chain[endpoint] && chain[endpoint].supported) {
+        // Temporary filter: Remove Arbitrum chains from Token Holders API
+        // These chains are not actually supported despite what the API returns
+        if (endpoint === 'token_holders' && (chain.chain_id === 42161 || chain.chain_id === 42170)) {
+          continue;
+        }
         supportedChains.push(chain);
       }
     }


### PR DESCRIPTION
Remove Arbitrum and Arbitrum Nova from the Token Holders API documentation.

The backend API (`api.sim.dune.com/v1/evm/supported-chains`) incorrectly reports Arbitrum (42161) and Arbitrum Nova (42170) as supporting the Token Holders API. This PR implements a temporary client-side filter to hide these chains from the documentation until the backend can be updated.

---
Linear Issue: [API-3698](https://linear.app/dune/issue/API-3698/remove-arbitrum-from-token-holders-api)

<a href="https://cursor.com/background-agent?bcId=bc-fbf5c817-5610-4ffd-ad0c-0320fc35c3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbf5c817-5610-4ffd-ad0c-0320fc35c3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

