### PR TITLE
Documentation chain_ids parameter correction

### DIFF
--- a/evm/supported-chains.mdx
+++ b/evm/supported-chains.mdx
@@ -126,7 +126,7 @@ When using `chain_ids`, you can request chains in several ways:
 
 Some supported chains have **no tag assigned**.
 A chain may be untagged due to higher latency, restrictive rate limits, RPC cost, or a temporary incident.
-Untagged chains stay out of default requests to keep them fast, but you can still query them with `chain_ids` by passing the chain name (e.g. `?chain_ids=corn,funkichain`).
+Untagged chains stay out of default requests to keep them fast, but you can still query them by passing in their numerical IDs (e.g. `chain_ids=21000000` for corn).
 
 Open the accordion above and scan the table to see which chains carry tags and which are untagged.
 


### PR DESCRIPTION
Correct documentation for the `chain_ids` parameter to specify numerical IDs instead of chain names.

---
Linear Issue: [API-3740](https://linear.app/dune/issue/API-3740/correct-chain-ids-parameter-documentation-for-supported-chains)

<a href="https://cursor.com/background-agent?bcId=bc-067aa2a3-863f-4f9b-8d4c-19b03b66ff84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-067aa2a3-863f-4f9b-8d4c-19b03b66ff84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

