### PR TITLE
Fixing the supported chain inaccuracy.

### DIFF
--- a/evm/supported-chains.mdx
+++ b/evm/supported-chains.mdx
@@ -126,7 +126,7 @@ When using `chain_ids`, you can request chains in several ways:
 
 Some supported chains have **no tag assigned**.
 A chain may be untagged due to higher latency, restrictive rate limits, RPC cost, or a temporary incident.
-Untagged chains stay out of default requests to keep them fast, but you can still query them with `chain_ids` by passing the chain name (e.g. `?chain_ids=corn,funkichain`).
+Untagged chains stay out of default requests to keep them fast, but you can still query them with `chain_ids` by passing their numerical chain id (e.g. `chain_ids=21000000` for corn).
 
 Open the accordion above and scan the table to see which chains carry tags and which are untagged.
 


### PR DESCRIPTION
You need to pass in the chain id for untagged chains, not the chain name. Thank you, @chrisdotn.