### PR TITLE
Retry cursor attempt

### DIFF
--- a/evm/activity.mdx
+++ b/evm/activity.mdx
@@ -32,6 +32,32 @@ Each activity includes detailed information such as:
 Activities are mostly indexed events. There are, of course, no events for native token transfers (wen [7708](https://ethereum-magicians.org/t/eip-7708-eth-transfers-emit-a-log/20034)?). We do have a heuristic to catch very simple native token transfers, where the native token transfer is the entirety of the transaction, but unfortunately we don't currently catch native token transfers that happen within internal txns.
 </Callout>
 
+## Unsupported Chain IDs
+
+When you request chain IDs that are not supported, the API will return a warning in the response instead of throwing an error. The `warnings` field will contain information about which chain IDs were not supported, and activity will be returned only for the supported chains.
+
+For example, if you request `chain_ids=1,9999,10,77777777777`:
+
+```json
+{
+  "activity": [
+    // Activity for chains 1 and 10 only
+  ],
+  "warnings": [
+    {
+      "code": "UNSUPPORTED_CHAIN_IDS",
+      "message": "Some requested chain_ids are not supported. Activity is returned only for supported chains.",
+      "chain_ids": [9999, 77777777777],
+      "docs_url": "https://docs.sim.dune.com/evm/supported-chains"
+    }
+  ]
+}
+```
+
+<Note>
+  Invalid chain ID tags (like typos in tag names) will still return errors as designed. Only invalid numeric chain IDs generate warnings.
+</Note>
+
 ## Data Finality & Re-orgs
 
 Sim APIs are designed to automatically detect and handle blockchain re-organizations.

--- a/evm/balances.mdx
+++ b/evm/balances.mdx
@@ -73,6 +73,33 @@ When set, each balance includes a `historical_prices` array with one entry per o
   The maximum number of historical price offsets is 3. If more than 3 are provided, the API returns an error.
 </Warning>
 
+## Unsupported Chain IDs
+
+When you request chain IDs that are not supported, the API will return a warning in the response instead of throwing an error. The `warnings` field will contain information about which chain IDs were not supported, and balances will be returned only for the supported chains.
+
+For example, if you request `chain_ids=1,9999,10,77777777777`:
+
+```json
+{
+  "wallet_address": "0x37305b1cd40574e4c5ce33f8e8306be057fd7341",
+  "balances": [
+    // Balances for chains 1 and 10 only
+  ],
+  "warnings": [
+    {
+      "code": "UNSUPPORTED_CHAIN_IDS",
+      "message": "Some requested chain_ids are not supported. Balances are returned only for supported chains.",
+      "chain_ids": [9999, 77777777777],
+      "docs_url": "https://docs.sim.dune.com/evm/supported-chains"
+    }
+  ]
+}
+```
+
+<Note>
+  Invalid chain ID tags (like typos in tag names) will still return errors as designed. Only invalid numeric chain IDs generate warnings.
+</Note>
+
 ## Pagination
 
 This endpoint is using cursor based pagination. You can use the `limit` query parameter to define the maximum page size.

--- a/evm/openapi/activity.json
+++ b/evm/openapi/activity.json
@@ -324,6 +324,38 @@
           }
         }
       },
+      "Warning": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Warning code identifier",
+            "example": "UNSUPPORTED_CHAIN_IDS"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable warning message",
+            "example": "Some requested chain_ids are not supported. Activity is returned only for supported chains."
+          },
+          "chain_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "List of chain IDs that triggered this warning"
+          },
+          "docs_url": {
+            "type": "string",
+            "description": "URL to relevant documentation",
+            "example": "https://docs.sim.dune.com/evm/supported-chains"
+          }
+        }
+      },
       "ActivityResponse": {
         "type": "object",
         "required": [
@@ -336,6 +368,13 @@
               "$ref": "#/components/schemas/ActivityItem"
             },
             "description": "Array of activity items"
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Warning"
+            },
+            "description": "Array of warnings about the request. For example, warnings about unsupported chain IDs."
           },
           "next_offset": {
             "type": "string",

--- a/evm/openapi/balances.json
+++ b/evm/openapi/balances.json
@@ -431,6 +431,38 @@
           }
         }
       },
+      "Warning": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Warning code identifier",
+            "example": "UNSUPPORTED_CHAIN_IDS"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable warning message",
+            "example": "Some requested chain_ids are not supported. Balances are returned only for supported chains."
+          },
+          "chain_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "List of chain IDs that triggered this warning"
+          },
+          "docs_url": {
+            "type": "string",
+            "description": "URL to relevant documentation",
+            "example": "https://docs.sim.dune.com/evm/supported-chains"
+          }
+        }
+      },
       "BalancesResponse": {
         "type": "object",
         "required": [
@@ -450,6 +482,13 @@
                 "$ref": "#/components/schemas/BalanceErrors"
               }
             ]
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Warning"
+            },
+            "description": "Array of warnings about the request. For example, warnings about unsupported chain IDs."
           },
           "next_offset": {
             "type": "string",
@@ -481,6 +520,13 @@
           "balances": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/BalanceData" }
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Warning"
+            },
+            "description": "Array of warnings about the request. For example, warnings about unsupported chain IDs."
           },
           "request_time": { "type": "string", "format": "date-time" },
           "response_time": { "type": "string", "format": "date-time" },

--- a/evm/openapi/transactions.json
+++ b/evm/openapi/transactions.json
@@ -453,6 +453,38 @@
           }
         }
       },
+      "Warning": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Warning code identifier",
+            "example": "UNSUPPORTED_CHAIN_IDS"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable warning message",
+            "example": "Some requested chain_ids are not supported. Transactions are returned only for supported chains."
+          },
+          "chain_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "List of chain IDs that triggered this warning"
+          },
+          "docs_url": {
+            "type": "string",
+            "description": "URL to relevant documentation",
+            "example": "https://docs.sim.dune.com/evm/supported-chains"
+          }
+        }
+      },
       "TransactionsResponse": {
         "type": "object",
         "required": [
@@ -472,6 +504,13 @@
                 "$ref": "#/components/schemas/TransactionErrors"
               }
             ]
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Warning"
+            },
+            "description": "Array of warnings about the request. For example, warnings about unsupported chain IDs."
           },
           "next_offset": {
             "type": "string"

--- a/evm/transactions.mdx
+++ b/evm/transactions.mdx
@@ -14,6 +14,33 @@ Transactions are ordered by descending block time, so the most recent transactio
 
 <SupportedChains endpoint="transactions" />
 
+## Unsupported Chain IDs
+
+When you request chain IDs that are not supported, the API will return a warning in the response instead of throwing an error. The `warnings` field will contain information about which chain IDs were not supported, and transactions will be returned only for the supported chains.
+
+For example, if you request `chain_ids=1,9999,10,77777777777`:
+
+```json
+{
+  "wallet_address": "0x37305b1cd40574e4c5ce33f8e8306be057fd7341",
+  "transactions": [
+    // Transactions for chains 1 and 10 only
+  ],
+  "warnings": [
+    {
+      "code": "UNSUPPORTED_CHAIN_IDS",
+      "message": "Some requested chain_ids are not supported. Transactions are returned only for supported chains.",
+      "chain_ids": [9999, 77777777777],
+      "docs_url": "https://docs.sim.dune.com/evm/supported-chains"
+    }
+  ]
+}
+```
+
+<Note>
+  Invalid chain ID tags (like typos in tag names) will still return errors as designed. Only invalid numeric chain IDs generate warnings.
+</Note>
+
 ## Decoded transactions
 
 Enable decoded transaction data and logs by adding the `?decode=true` query parameter to your request.


### PR DESCRIPTION
Update documentation and OpenAPI specifications for Balances, Activity, and Transactions APIs to include the new `warnings` field for unsupported chain IDs.

This change reflects a backend update where the API now returns warnings for unsupported numeric chain IDs, allowing partial results for valid chains, rather than returning an error for the entire request. The documentation clarifies this behavior, distinguishing it from errors still returned for invalid chain ID tags.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C0766JKCP89/p1765905520825629?thread_ts=1765905520.825629&cid=C0766JKCP89)

<a href="https://cursor.com/background-agent?bcId=bc-9b84b140-188a-4f9c-a78e-f43b59d5a720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b84b140-188a-4f9c-a78e-f43b59d5a720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

