### PR TITLE
Chain id warnings infrastructure

### DIFF
--- a/error-handling.mdx
+++ b/error-handling.mdx
@@ -5,6 +5,44 @@ description: "How to handle errors when using Sim APIs"
 
 This guide explains how to handle errors when using Sim APIs, including common error codes, troubleshooting steps, and code examples for proper error handling.
 
+## Errors vs. Warnings
+
+Sim APIs distinguish between **errors** and **warnings**:
+
+- **Errors** indicate that the request failed and could not be fulfilled. The API returns an error response with an HTTP 4xx or 5xx status code.
+- **Warnings** indicate non-fatal issues where the request was partially fulfilled. The API returns a successful HTTP 200 response with data, but includes a `warnings` array to inform you about issues that occurred.
+
+### When Warnings Occur
+
+Warnings are currently used when you request data for specific chains via the `chain_ids` parameter and some of those chains are not supported. For example:
+
+- If you request `?chain_ids=1,9999,10` and chain 9999 is not supported, the API will return data for chains 1 and 10, plus a warning about chain 9999.
+
+### Warning Response Format
+
+When warnings are present, they appear in a `warnings` array within the successful (HTTP 200) response:
+
+```json
+{
+  "wallet_address": "0x37305b1cd40574e4c5ce33f8e8306be057fd7341",
+  "balances": [...],
+  "warnings": [
+    {
+      "code": "UNSUPPORTED_CHAIN_IDS",
+      "message": "Some requested chain_ids are not supported. Balances are returned only for supported chains.",
+      "chain_ids": [9999, 77777777777],
+      "docs_url": "https://docs.sim.dune.com/evm/supported-chains"
+    }
+  ]
+}
+```
+
+Each warning includes:
+- `code`: A machine-readable warning code (e.g., `UNSUPPORTED_CHAIN_IDS`)
+- `message`: A human-readable description of the warning
+- `chain_ids`: The list of chain IDs that caused this warning (for chain-related warnings)
+- `docs_url`: A link to relevant documentation for more information
+
 ## Error Response Format
 
 When an error occurs, Sim APIs return a JSON response with error information:
@@ -29,6 +67,58 @@ The error property can be either `"error"` or `"message"` depending on the type 
 | 404 | Resource not found | Verify the endpoint URL and resource identifiers |
 | 429 | Too many requests | Implement backoff strategies and consider upgrading your plan if you consistently hit limits |
 | 500 | Server-side error | Retry the request after a short delay; if persistent, contact support |
+
+## Handling Warnings in Code
+
+When processing API responses, check for the `warnings` array to be notified of non-fatal issues:
+
+<Tabs>
+<Tab title="JavaScript">
+```javascript
+const response = await fetch('https://api.sim.dune.com/v1/evm/balances/0xd8da6bf26964af9d7eed9e03e53415d37aa96045?chain_ids=1,9999,10', {
+  headers: {'X-Sim-Api-Key': 'YOUR_API_KEY'}
+});
+
+const data = await response.json();
+
+// Check for warnings
+if (data.warnings && data.warnings.length > 0) {
+  data.warnings.forEach(warning => {
+    if (warning.code === 'UNSUPPORTED_CHAIN_IDS') {
+      console.warn(`Warning: Chains ${warning.chain_ids.join(', ')} are not supported.`);
+      console.warn(`See: ${warning.docs_url}`);
+    }
+  });
+}
+
+// Process the data that was successfully returned
+console.log(`Found ${data.balances.length} balances`);
+```
+</Tab>
+<Tab title="Python">
+```python
+import requests
+
+response = requests.get(
+    'https://api.sim.dune.com/v1/evm/balances/0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+    headers={'X-Sim-Api-Key': 'YOUR_API_KEY'},
+    params={'chain_ids': '1,9999,10'}
+)
+
+data = response.json()
+
+# Check for warnings
+if 'warnings' in data and len(data['warnings']) > 0:
+    for warning in data['warnings']:
+        if warning['code'] == 'UNSUPPORTED_CHAIN_IDS':
+            print(f"Warning: Chains {warning['chain_ids']} are not supported.")
+            print(f"See: {warning['docs_url']}")
+
+# Process the data that was successfully returned
+print(f"Found {len(data['balances'])} balances")
+```
+</Tab>
+</Tabs>
 
 ## Handling Errors in Code
 

--- a/evm/activity.mdx
+++ b/evm/activity.mdx
@@ -38,6 +38,54 @@ Sim APIs are designed to automatically detect and handle blockchain re-organizat
 We detect any potentially broken parent-child block relationships as soon as they arise and update our internal state to match the onchain state, typically within a few hundred milliseconds.
 This re-org handling is an automatic, non-configurable feature designed to provide the most reliable data.
 
+## Warnings
+
+When requesting activity for specific chains using the `chain_ids` parameter, the API may return warnings if some requested chain IDs are not supported. Unlike errors, warnings indicate non-fatal issues where the request can still be partially fulfilled.
+
+When unsupported chain IDs are included in your request, the API will:
+- Return activity for all supported chains you requested
+- Include a `warnings` array in the response with details about the unsupported chains
+
+### Example: Request with Unsupported Chain IDs
+
+If you request `?chain_ids=1,9999,10`, the API returns activity for chains 1 and 10 (supported), and includes a warning about chain 9999 (unsupported):
+
+```json
+{
+  "activity": [
+    {
+      "chain_id": 1,
+      "block_number": 18500000,
+      "block_time": "2025-02-20T13:52:29+00:00",
+      "tx_hash": "0x184544c8d67a0cbed0a3f04abe5f958b96635e8c743c070f70e24b1c06cd1aa6",
+      "type": "receive",
+      "asset_type": "erc20",
+      "token_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "from": "0xd152f549545093347a162dce210e7293f1452150",
+      "value": "1000000",
+      "value_usd": 1.0,
+      "token_metadata": {
+        "symbol": "USDC",
+        "decimals": 6,
+        "price_usd": 1.0
+      }
+    }
+  ],
+  "warnings": [
+    {
+      "code": "UNSUPPORTED_CHAIN_IDS",
+      "message": "Some requested chain_ids are not supported. Activity is returned only for supported chains.",
+      "chain_ids": [9999],
+      "docs_url": "https://docs.sim.dune.com/evm/supported-chains"
+    }
+  ]
+}
+```
+
+<Tip>
+  Check the [Supported Chains](/evm/supported-chains) page to see which chains are currently supported for the Activity endpoint.
+</Tip>
+
 ## Token Filtering
 
 We include all the data needed for custom filtering in the responses, allowing you to implement your own filtering logic. For a detailed explanation of our approach, see our [Token Filtering](/token-filtering) guide.

--- a/evm/balances.mdx
+++ b/evm/balances.mdx
@@ -73,6 +73,58 @@ When set, each balance includes a `historical_prices` array with one entry per o
   The maximum number of historical price offsets is 3. If more than 3 are provided, the API returns an error.
 </Warning>
 
+## Warnings
+
+When requesting balances for specific chains using the `chain_ids` parameter, the API may return warnings if some requested chain IDs are not supported. Unlike errors, warnings indicate non-fatal issues where the request can still be partially fulfilled.
+
+When unsupported chain IDs are included in your request, the API will:
+- Return balances for all supported chains you requested
+- Include a `warnings` array in the response with details about the unsupported chains
+
+### Example: Request with Unsupported Chain IDs
+
+If you request `?chain_ids=1,9999,10,77777777777`, the API returns balances for chains 1 and 10 (supported), and includes a warning about chains 9999 and 77777777777 (unsupported):
+
+```json
+{
+  "wallet_address": "0x37305b1cd40574e4c5ce33f8e8306be057fd7341",
+  "balances": [
+    {
+      "chain": "ethereum",
+      "chain_id": 1,
+      "address": "native",
+      "amount": "1000000000000000000",
+      "symbol": "ETH",
+      "decimals": 18,
+      "price_usd": 3896.8315,
+      "value_usd": 3896.8315
+    },
+    {
+      "chain": "optimism",
+      "chain_id": 10,
+      "address": "native",
+      "amount": "500000000000000000",
+      "symbol": "ETH",
+      "decimals": 18,
+      "price_usd": 3896.8315,
+      "value_usd": 1948.41575
+    }
+  ],
+  "warnings": [
+    {
+      "code": "UNSUPPORTED_CHAIN_IDS",
+      "message": "Some requested chain_ids are not supported. Balances are returned only for supported chains.",
+      "chain_ids": [9999, 77777777777],
+      "docs_url": "https://docs.sim.dune.com/evm/supported-chains"
+    }
+  ]
+}
+```
+
+<Tip>
+  Check the [Supported Chains](/evm/supported-chains) page to see which chains are currently supported for the Balances endpoint.
+</Tip>
+
 ## Pagination
 
 This endpoint is using cursor based pagination. You can use the `limit` query parameter to define the maximum page size.

--- a/evm/openapi/activity.json
+++ b/evm/openapi/activity.json
@@ -83,28 +83,66 @@
                 "schema": {
                   "$ref": "#/components/schemas/ActivityResponse"
                 },
-                "example": {
-                  "activity": [
-                    {
-                      "chain_id": 8453,
-                      "block_number": 26635101,
-                      "block_time": "2025-02-20T13:52:29+00:00",
-                      "tx_hash": "0x184544c8d67a0cbed0a3f04abe5f958b96635e8c743c070f70e24b1c06cd1aa6",
-                      "type": "receive",
-                      "asset_type": "erc20",
-                      "token_address": "0xf92e740ad181b13a484a886ed16aa6d32d71b19a",
-                      "from": "0xd152f549545093347a162dce210e7293f1452150",
-                      "value": "123069652500000000000",
-                      "value_usd": 0.14017463965013963,
-                      "token_metadata": {
-                        "symbol": "ENT",
-                        "decimals": 18,
-                        "price_usd": 0.001138986230989314,
-                        "pool_size": 5.2274054439382835
-                      }
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "activity": [
+                        {
+                          "chain_id": 8453,
+                          "block_number": 26635101,
+                          "block_time": "2025-02-20T13:52:29+00:00",
+                          "tx_hash": "0x184544c8d67a0cbed0a3f04abe5f958b96635e8c743c070f70e24b1c06cd1aa6",
+                          "type": "receive",
+                          "asset_type": "erc20",
+                          "token_address": "0xf92e740ad181b13a484a886ed16aa6d32d71b19a",
+                          "from": "0xd152f549545093347a162dce210e7293f1452150",
+                          "value": "123069652500000000000",
+                          "value_usd": 0.14017463965013963,
+                          "token_metadata": {
+                            "symbol": "ENT",
+                            "decimals": 18,
+                            "price_usd": 0.001138986230989314,
+                            "pool_size": 5.2274054439382835
+                          }
+                        }
+                      ],
+                      "next_offset": "KgAAAAAAAAAweDQ4ZDAwNGE2YzE3NWRiMzMxZTk5YmVhZjY0NDIzYjMwOTgzNTdhZTdAVxVC-y0GAAUhAAAAAAAA6XCRAQAAAAAAAAAAAAAAAD0AAAAAAAAAAAAAAAAAAAA"
                     }
-                  ],
-                  "next_offset": "KgAAAAAAAAAweDQ4ZDAwNGE2YzE3NWRiMzMxZTk5YmVhZjY0NDIzYjMwOTgzNTdhZTdAVxVC-y0GAAUhAAAAAAAA6XCRAQAAAAAAAAAAAAAAAD0AAAAAAAAAAAAAAAAAAAA"
+                  },
+                  "with_warnings": {
+                    "summary": "Response with unsupported chain IDs warning",
+                    "value": {
+                      "activity": [
+                        {
+                          "chain_id": 1,
+                          "block_number": 18500000,
+                          "block_time": "2025-02-20T13:52:29+00:00",
+                          "tx_hash": "0x184544c8d67a0cbed0a3f04abe5f958b96635e8c743c070f70e24b1c06cd1aa6",
+                          "type": "receive",
+                          "asset_type": "erc20",
+                          "token_address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                          "from": "0xd152f549545093347a162dce210e7293f1452150",
+                          "value": "1000000",
+                          "value_usd": 1.0,
+                          "token_metadata": {
+                            "symbol": "USDC",
+                            "decimals": 6,
+                            "price_usd": 1.0
+                          }
+                        }
+                      ],
+                      "warnings": [
+                        {
+                          "code": "UNSUPPORTED_CHAIN_IDS",
+                          "message": "Some requested chain_ids are not supported. Activity is returned only for supported chains.",
+                          "chain_ids": [9999, 77777777777],
+                          "docs_url": "https://docs.sim.dune.com/evm/supported-chains"
+                        }
+                      ],
+                      "next_offset": "KgAAAAAAAAAweDQ4ZDAwNGE2YzE3NWRiMzMxZTk5YmVhZjY0NDIzYjMwOTgzNTdhZTdAVxVC-y0GAAUhAAAAAAAA6XCRAQAAAAAAAAAAAAAAAD0AAAAAAAAAAAAAAAAAAAA"
+                    }
+                  }
                 }
               }
             }
@@ -324,6 +362,38 @@
           }
         }
       },
+      "Warning": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Warning code identifier (e.g., 'UNSUPPORTED_CHAIN_IDS')",
+            "example": "UNSUPPORTED_CHAIN_IDS"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable warning message",
+            "example": "Some requested chain_ids are not supported. Activity is returned only for supported chains."
+          },
+          "chain_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "List of chain IDs that triggered this warning (for chain-related warnings)"
+          },
+          "docs_url": {
+            "type": "string",
+            "description": "URL to documentation with more information about the warning",
+            "example": "https://docs.sim.dune.com/evm/supported-chains"
+          }
+        }
+      },
       "ActivityResponse": {
         "type": "object",
         "required": [
@@ -336,6 +406,13 @@
               "$ref": "#/components/schemas/ActivityItem"
             },
             "description": "Array of activity items"
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Warning"
+            },
+            "description": "Array of warnings that occurred during request processing. Warnings indicate non-fatal issues (e.g., unsupported chain IDs) where the request can still be partially fulfilled."
           },
           "next_offset": {
             "type": "string",

--- a/evm/openapi/balances.json
+++ b/evm/openapi/balances.json
@@ -166,6 +166,44 @@
                         "request_time": "2025-08-13T10:31:08Z",
                         "response_time": "2025-08-13T10:31:08Z"
                     }
+                  },
+                  "with_warnings": {
+                    "summary": "Response with unsupported chain IDs warning",
+                    "value": {
+                      "wallet_address": "0x37305b1cd40574e4c5ce33f8e8306be057fd7341",
+                      "balances": [
+                        {
+                          "chain": "ethereum",
+                          "chain_id": 1,
+                          "address": "native",
+                          "amount": "1000000000000000000",
+                          "symbol": "ETH",
+                          "decimals": 18,
+                          "price_usd": 3896.8315,
+                          "value_usd": 3896.8315
+                        },
+                        {
+                          "chain": "optimism",
+                          "chain_id": 10,
+                          "address": "native",
+                          "amount": "500000000000000000",
+                          "symbol": "ETH",
+                          "decimals": 18,
+                          "price_usd": 3896.8315,
+                          "value_usd": 1948.41575
+                        }
+                      ],
+                      "warnings": [
+                        {
+                          "code": "UNSUPPORTED_CHAIN_IDS",
+                          "message": "Some requested chain_ids are not supported. Balances are returned only for supported chains.",
+                          "chain_ids": [9999, 77777777777],
+                          "docs_url": "https://docs.sim.dune.com/evm/supported-chains"
+                        }
+                      ],
+                      "request_time": "2025-12-16T10:31:08Z",
+                      "response_time": "2025-12-16T10:31:08Z"
+                    }
                   }
                 }
               }
@@ -431,6 +469,38 @@
           }
         }
       },
+      "Warning": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Warning code identifier (e.g., 'UNSUPPORTED_CHAIN_IDS')",
+            "example": "UNSUPPORTED_CHAIN_IDS"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable warning message",
+            "example": "Some requested chain_ids are not supported. Balances are returned only for supported chains."
+          },
+          "chain_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "List of chain IDs that triggered this warning (for chain-related warnings)"
+          },
+          "docs_url": {
+            "type": "string",
+            "description": "URL to documentation with more information about the warning",
+            "example": "https://docs.sim.dune.com/evm/supported-chains"
+          }
+        }
+      },
       "BalancesResponse": {
         "type": "object",
         "required": [
@@ -450,6 +520,13 @@
                 "$ref": "#/components/schemas/BalanceErrors"
               }
             ]
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Warning"
+            },
+            "description": "Array of warnings that occurred during request processing. Warnings indicate non-fatal issues (e.g., unsupported chain IDs) where the request can still be partially fulfilled."
           },
           "next_offset": {
             "type": "string",
@@ -481,6 +558,11 @@
           "balances": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/BalanceData" }
+          },
+          "warnings": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Warning" },
+            "description": "Array of warnings that occurred during request processing. Warnings indicate non-fatal issues (e.g., unsupported chain IDs) where the request can still be partially fulfilled."
           },
           "request_time": { "type": "string", "format": "date-time" },
           "response_time": { "type": "string", "format": "date-time" },

--- a/evm/openapi/transactions.json
+++ b/evm/openapi/transactions.json
@@ -93,168 +93,123 @@
                 "schema": {
                   "$ref": "#/components/schemas/TransactionsResponse"
                 },
-                "example": {
-                  "transactions": [
-                    {
-                      "address": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa",
-                      "block_hash": "0x745bdf699cee1fef27b9304be43a2435c744500ef455cc6b7dfb4c34417601a2",
-                      "block_number": "30819446",
-                      "block_time": "2025-05-28T10:30:39Z",
-                      "chain": "base",
-                      "from": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa",
-                      "to": "0x6ff5693b99212da76ad316178a184ab56d299b43",
-                      "data": "0x3593564c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000006836ecce000000000000000000000000000000000000000000000000000000000000000308060c000000000000000000000000000000000000000000000000000000000000",
-                      "gas_price": "0x5aaa88",
-                      "hash": "0x1081ebf623669338e9de6865d08d7ff3a3d1b0ef6f6486b350c3caf5b2e9257d",
-                      "index": "35",
-                      "nonce": "0x8",
-                      "transaction_type": "0x2",
-                      "value": "0x0",
-                      "decoded": {
-                        "name": "execute",
-                        "inputs": [
-                          {
-                            "name": "_commands",
-                            "type": "bytes",
-                            "value": "0x08060c"
-                          },
-                          {
-                            "name": "_inputs",
-                            "type": "bytes[]",
-                            "value": [
-                              "0x000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000186a0"
-                            ]
-                          },
-                          {
-                            "name": "_deadline",
-                            "type": "uint256",
-                            "value": "1748430030"
-                          }
-                        ]
-                      },
-                      "logs": [
+                "examples": {
+                  "success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "transactions": [
                         {
-                          "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
-                          "data": "0x00000000000000000000000000000000000000000000000000000000000186a0",
-                          "topics": [
-                            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-                            "0x0000000000000000000000007532cd0651030d3dc80b28199a125fc9f5ac80fa",
-                            "0x00000000000000000000000088a43bbdf9d098eec7bceda4e2494615dfd9bb9c"
-                          ],
+                          "address": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa",
+                          "block_hash": "0x745bdf699cee1fef27b9304be43a2435c744500ef455cc6b7dfb4c34417601a2",
+                          "block_number": "30819446",
+                          "block_time": "2025-05-28T10:30:39Z",
+                          "chain": "base",
+                          "from": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa",
+                          "to": "0x6ff5693b99212da76ad316178a184ab56d299b43",
+                          "data": "0x3593564c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000006836ecce000000000000000000000000000000000000000000000000000000000000000308060c000000000000000000000000000000000000000000000000000000000000",
+                          "gas_price": "0x5aaa88",
+                          "hash": "0x1081ebf623669338e9de6865d08d7ff3a3d1b0ef6f6486b350c3caf5b2e9257d",
+                          "index": "35",
+                          "nonce": "0x8",
+                          "transaction_type": "0x2",
+                          "value": "0x0",
                           "decoded": {
-                            "name": "Transfer",
+                            "name": "execute",
                             "inputs": [
                               {
-                                "name": "sender",
-                                "type": "address",
-                                "value": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa"
+                                "name": "_commands",
+                                "type": "bytes",
+                                "value": "0x08060c"
                               },
                               {
-                                "name": "to",
-                                "type": "address",
-                                "value": "0x88a43bbdf9d098eec7bceda4e2494615dfd9bb9c"
+                                "name": "_inputs",
+                                "type": "bytes[]",
+                                "value": [
+                                  "0x000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000186a0"
+                                ]
                               },
                               {
-                                "name": "value",
+                                "name": "_deadline",
                                 "type": "uint256",
-                                "value": "100000"
+                                "value": "1748430030"
                               }
                             ]
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "address": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa",
-                      "block_hash": "0x76947181fe3fe124085e1de7dc9494312cd417c02dd4f279da75bcca1e24c7d4",
-                      "block_number": "30819278",
-                      "block_time": "2025-05-28T10:25:03Z",
-                      "chain": "base",
-                      "from": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa",
-                      "to": "0x6ff5693b99212da76ad316178a184ab56d299b43",
-                      "data": "0x3593564c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000006836eb82",
-                      "gas_price": "0x2a6b28",
-                      "hash": "0xa1e2251a9ccad288024bddbd8ba983ef9de8caf4f46bed2dc72be4550edee2be",
-                      "index": "81",
-                      "nonce": "0x7",
-                      "transaction_type": "0x2",
-                      "value": "0x0",
-                      "decoded": {
-                        "name": "execute",
-                        "inputs": [
-                          {
-                            "name": "_commands",
-                            "type": "bytes",
-                            "value": "0x0a100604"
                           },
-                          {
-                            "name": "_inputs",
-                            "type": "bytes[]",
-                            "value": [
-                              "0x000000000000000000000000833589fcd6edb6e08f4c7c32d4f71b54bda02913000000000000000000000000ffffffffffffffffffffffffffffffffffffffff"
-                            ]
-                          },
-                          {
-                            "name": "_deadline",
-                            "type": "uint256",
-                            "value": "1748429698"
-                          }
-                        ]
-                      },
-                      "logs": [
-                        {
-                          "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
-                          "data": "0x0000000000000000000000000000000000000000000000000000000000030d40",
-                          "topics": [
-                            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-                            "0x0000000000000000000000007532cd0651030d3dc80b28199a125fc9f5ac80fa",
-                            "0x000000000000000000000000498581ff718922c3f8e6a244956af099b2652b2b"
-                          ],
-                          "decoded": {
-                            "name": "Transfer",
-                            "inputs": [
-                              {
-                                "name": "sender",
-                                "type": "address",
-                                "value": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa"
-                              },
-                              {
-                                "name": "to",
-                                "type": "address",
-                                "value": "0x498581ff718922c3f8e6a244956af099b2652b2b"
-                              },
-                              {
-                                "name": "value",
-                                "type": "uint256",
-                                "value": "200000"
+                          "logs": [
+                            {
+                              "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+                              "data": "0x00000000000000000000000000000000000000000000000000000000000186a0",
+                              "topics": [
+                                "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                                "0x0000000000000000000000007532cd0651030d3dc80b28199a125fc9f5ac80fa",
+                                "0x00000000000000000000000088a43bbdf9d098eec7bceda4e2494615dfd9bb9c"
+                              ],
+                              "decoded": {
+                                "name": "Transfer",
+                                "inputs": [
+                                  {
+                                    "name": "sender",
+                                    "type": "address",
+                                    "value": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa"
+                                  },
+                                  {
+                                    "name": "to",
+                                    "type": "address",
+                                    "value": "0x88a43bbdf9d098eec7bceda4e2494615dfd9bb9c"
+                                  },
+                                  {
+                                    "name": "value",
+                                    "type": "uint256",
+                                    "value": "100000"
+                                  }
+                                ]
                               }
-                            ]
-                          }
+                            }
+                          ]
                         }
-                      ]
-                    },
-                    {
-                      "address": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa",
-                      "block_hash": "0x90f2b615c81dbf0dcc4f61e0dc9a6101cee206bd923e31829d3b18a6c4553eb9",
-                      "block_number": "21554172",
-                      "block_time": "2025-02-06T21:17:12Z",
-                      "chain": "base_sepolia",
-                      "from": "0xbab76e4365a2dff89ddb2d3fc9994103b48886c0",
-                      "to": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa",
-                      "data": "0x",
-                      "gas_price": "0x174876e800",
-                      "hash": "0x7ab170893e06abeaa5aa88e2e6d25873e7635b2da49484b9422359491fd6774b",
-                      "index": "1",
-                      "nonce": "0x1773d",
-                      "transaction_type": "0x2",
-                      "value": "0xb1a2bc2ec50000",
-                      "logs": []
+                      ],
+                      "next_offset": "QBHrUqbdBQDkBwAAAAAAACHjyAAAAAAAAAAAAAAAAAACAAAAAAAAAA",
+                      "request_time": "2025-05-28T10:31:56Z",
+                      "response_time": "2025-05-28T10:31:56Z",
+                      "wallet_address": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa"
                     }
-                  ],
-                  "next_offset": "QBHrUqbdBQDkBwAAAAAAACHjyAAAAAAAAAAAAAAAAAACAAAAAAAAAA",
-                  "request_time": "2025-05-28T10:31:56Z",
-                  "response_time": "2025-05-28T10:31:56Z",
-                  "wallet_address": "0x7532cd0651030d3dc80b28199a125fc9f5ac80fa"
+                  },
+                  "with_warnings": {
+                    "summary": "Response with unsupported chain IDs warning",
+                    "value": {
+                      "transactions": [
+                        {
+                          "address": "0x37305b1cd40574e4c5ce33f8e8306be057fd7341",
+                          "block_hash": "0x745bdf699cee1fef27b9304be43a2435c744500ef455cc6b7dfb4c34417601a2",
+                          "block_number": "30819446",
+                          "block_time": "2025-05-28T10:30:39Z",
+                          "chain": "ethereum",
+                          "from": "0x37305b1cd40574e4c5ce33f8e8306be057fd7341",
+                          "to": "0x6ff5693b99212da76ad316178a184ab56d299b43",
+                          "data": "0x",
+                          "gas_price": "0x5aaa88",
+                          "hash": "0x1081ebf623669338e9de6865d08d7ff3a3d1b0ef6f6486b350c3caf5b2e9257d",
+                          "index": "35",
+                          "nonce": "0x8",
+                          "transaction_type": "0x2",
+                          "value": "0x0",
+                          "logs": []
+                        }
+                      ],
+                      "warnings": [
+                        {
+                          "code": "UNSUPPORTED_CHAIN_IDS",
+                          "message": "Some requested chain_ids are not supported. Transactions are returned only for supported chains.",
+                          "chain_ids": [9999, 77777777777],
+                          "docs_url": "https://docs.sim.dune.com/evm/supported-chains"
+                        }
+                      ],
+                      "next_offset": "QBHrUqbdBQDkBwAAAAAAACHjyAAAAAAAAAAAAAAAAAACAAAAAAAAAA",
+                      "request_time": "2025-12-16T10:31:56Z",
+                      "response_time": "2025-12-16T10:31:56Z",
+                      "wallet_address": "0x37305b1cd40574e4c5ce33f8e8306be057fd7341"
+                    }
+                  }
                 }
               }
             }
@@ -453,6 +408,38 @@
           }
         }
       },
+      "Warning": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Warning code identifier (e.g., 'UNSUPPORTED_CHAIN_IDS')",
+            "example": "UNSUPPORTED_CHAIN_IDS"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable warning message",
+            "example": "Some requested chain_ids are not supported. Transactions are returned only for supported chains."
+          },
+          "chain_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "List of chain IDs that triggered this warning (for chain-related warnings)"
+          },
+          "docs_url": {
+            "type": "string",
+            "description": "URL to documentation with more information about the warning",
+            "example": "https://docs.sim.dune.com/evm/supported-chains"
+          }
+        }
+      },
       "TransactionsResponse": {
         "type": "object",
         "required": [
@@ -472,6 +459,13 @@
                 "$ref": "#/components/schemas/TransactionErrors"
               }
             ]
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Warning"
+            },
+            "description": "Array of warnings that occurred during request processing. Warnings indicate non-fatal issues (e.g., unsupported chain IDs) where the request can still be partially fulfilled."
           },
           "next_offset": {
             "type": "string"

--- a/evm/transactions.mdx
+++ b/evm/transactions.mdx
@@ -28,6 +28,49 @@ For more details, see the [response information](#response-logs-decoded) below.
   Decoding is only available for contracts that exist on [Dune.com](https://dune.com). Search for your contract on Dune to check if it's available for decoding. Transactions without logs, logs without known signatures, or contracts not indexed on Dune **will not** include decoded data.
 </Note>
 
+## Warnings
+
+When requesting transactions for specific chains using the `chain_ids` parameter, the API may return warnings if some requested chain IDs are not supported. Unlike errors, warnings indicate non-fatal issues where the request can still be partially fulfilled.
+
+When unsupported chain IDs are included in your request, the API will:
+- Return transactions for all supported chains you requested
+- Include a `warnings` array in the response with details about the unsupported chains
+
+### Example: Request with Unsupported Chain IDs
+
+If you request `?chain_ids=1,9999,10`, the API returns transactions for chains 1 and 10 (supported), and includes a warning about chain 9999 (unsupported):
+
+```json
+{
+  "wallet_address": "0x37305b1cd40574e4c5ce33f8e8306be057fd7341",
+  "transactions": [
+    {
+      "address": "0x37305b1cd40574e4c5ce33f8e8306be057fd7341",
+      "block_hash": "0x745bdf699cee1fef27b9304be43a2435c744500ef455cc6b7dfb4c34417601a2",
+      "block_number": "30819446",
+      "block_time": "2025-05-28T10:30:39Z",
+      "chain": "ethereum",
+      "from": "0x37305b1cd40574e4c5ce33f8e8306be057fd7341",
+      "to": "0x6ff5693b99212da76ad316178a184ab56d299b43",
+      "hash": "0x1081ebf623669338e9de6865d08d7ff3a3d1b0ef6f6486b350c3caf5b2e9257d",
+      "value": "0x0"
+    }
+  ],
+  "warnings": [
+    {
+      "code": "UNSUPPORTED_CHAIN_IDS",
+      "message": "Some requested chain_ids are not supported. Transactions are returned only for supported chains.",
+      "chain_ids": [9999],
+      "docs_url": "https://docs.sim.dune.com/evm/supported-chains"
+    }
+  ]
+}
+```
+
+<Tip>
+  Check the [Supported Chains](/evm/supported-chains) page to see which chains are currently supported for the Transactions endpoint.
+</Tip>
+
 ## Pagination
 
 This endpoint is using cursor based pagination.


### PR DESCRIPTION
Document the new `warnings` field in API responses, allowing partial fulfillment of requests when unsupported chain IDs are provided.

Previously, requesting unsupported chain IDs would result in an error. With this update, the API now returns a successful response with data for supported chains and includes a `warnings` array to inform users about the unsupported chains.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C0766JKCP89/p1765905520825629?thread_ts=1765905520.825629&cid=C0766JKCP89)

<a href="https://cursor.com/background-agent?bcId=bc-1fc7d752-eda7-450f-9c67-ca9f32acf15b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1fc7d752-eda7-450f-9c67-ca9f32acf15b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

