### PR TITLE
SIM-4339: Add exclude_unpriced schema/docs to balances endpoints

### DIFF
--- a/.well-known/ai-tools.json
+++ b/.well-known/ai-tools.json
@@ -88,6 +88,10 @@
             "type": "boolean",
             "description": "When true, excludes tokens with less than 100 USD liquidity."
           },
+          "include_unpriced": {
+            "type": "boolean",
+            "description": "When true, includes token balances without available USD pricing. Default is false."
+          },
           "limit": {
             "type": "integer",
             "minimum": 1,
@@ -422,6 +426,10 @@
             "type": "string",
             "enum": ["erc20", "native"],
             "description": "Specify erc20 or native to get only ERC20 stablecoins or native stablecoins (e.g. xDAI on Gnosis)."
+          },
+          "include_unpriced": {
+            "type": "boolean",
+            "description": "When true, includes token balances without available USD pricing. Default is false."
           },
           "limit": {
             "type": "integer",

--- a/.well-known/ai-tools.json
+++ b/.well-known/ai-tools.json
@@ -88,9 +88,9 @@
             "type": "boolean",
             "description": "When true, excludes tokens with less than 100 USD liquidity."
           },
-          "include_unpriced": {
+          "exclude_unpriced": {
             "type": "boolean",
-            "description": "When true, includes token balances without available USD pricing. Default is false."
+            "description": "When true, excludes token balances without available USD pricing. Default is false."
           },
           "limit": {
             "type": "integer",
@@ -427,9 +427,9 @@
             "enum": ["erc20", "native"],
             "description": "Specify erc20 or native to get only ERC20 stablecoins or native stablecoins (e.g. xDAI on Gnosis)."
           },
-          "include_unpriced": {
+          "exclude_unpriced": {
             "type": "boolean",
-            "description": "When true, includes token balances without available USD pricing. Default is false."
+            "description": "When true, excludes token balances without available USD pricing. Default is false."
           },
           "limit": {
             "type": "integer",

--- a/evm/balances.mdx
+++ b/evm/balances.mdx
@@ -32,9 +32,9 @@ You can include `metadata=pools` in your request to see which liquidity pool was
 
 We also include the `pool_size` field in all responses, allowing you to implement custom filtering logic based on your specific requirements. For a detailed explanation of our approach, see our [Token Filtering](/token-filtering) guide.
 
-### Include unpriced balances
+### Exclude unpriced balances
 
-By default, balances for tokens without available pricing data are excluded from responses. To include them, pass `include_unpriced=true`.
+By default, balances for tokens without available pricing data are included in responses. To filter them out, pass `exclude_unpriced=true`.
 
 ### Exclude tokens with less than 100 USD liquidity
 

--- a/evm/balances.mdx
+++ b/evm/balances.mdx
@@ -32,6 +32,10 @@ You can include `metadata=pools` in your request to see which liquidity pool was
 
 We also include the `pool_size` field in all responses, allowing you to implement custom filtering logic based on your specific requirements. For a detailed explanation of our approach, see our [Token Filtering](/token-filtering) guide.
 
+### Include unpriced balances
+
+By default, balances for tokens without available pricing data are excluded from responses. To include them, pass `include_unpriced=true`.
+
 ### Exclude tokens with less than 100 USD liquidity
 
 Use the optional `exclude_spam_tokens` query parameter to automatically filter out tokens with less than 100 USD of liquidity. Include the query parameter `exclude_spam_tokens=true` so that those tokens are excluded from the response entirely. This is distinct from the `low_liquidity` field in the response, which is `true` when liquidity is below 10,000. To learn more about how Sim calculates liquidity data, visit the [Token Filtering](/token-filtering) guide.

--- a/openapi.json
+++ b/openapi.json
@@ -401,6 +401,16 @@
             }
           },
           {
+            "name": "include_unpriced",
+            "in": "query",
+            "description": "When true, includes balances for tokens without available pricing data. By default, unpriced token balances are excluded.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
             "name": "historical_prices",
             "in": "query",
             "description": "Historical price selection. Provide a single integer or a comma-separated list of up to 3 integers representing hours in the past (e.g. `168` for 1 week ago or `720,168,24` for 1 month, 1 week, and 1 day ago). When set, each balance includes a historical_prices array with one entry per offset.",
@@ -1573,6 +1583,16 @@
             "name": "exclude_spam_tokens",
             "in": "query",
             "description": "When true, excludes tokens with less than 100 USD liquidity from the response. This differs from the `low_liquidity` field in the response.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "include_unpriced",
+            "in": "query",
+            "description": "When true, includes balances for tokens without available pricing data. By default, unpriced token balances are excluded.",
             "required": false,
             "schema": {
               "type": "boolean",

--- a/openapi.json
+++ b/openapi.json
@@ -401,9 +401,9 @@
             }
           },
           {
-            "name": "include_unpriced",
+            "name": "exclude_unpriced",
             "in": "query",
-            "description": "When true, includes balances for tokens without available pricing data. By default, unpriced token balances are excluded.",
+            "description": "When true, excludes balances for tokens without available pricing data. By default, unpriced token balances are included.",
             "required": false,
             "schema": {
               "type": "boolean",
@@ -1590,9 +1590,9 @@
             }
           },
           {
-            "name": "include_unpriced",
+            "name": "exclude_unpriced",
             "in": "query",
-            "description": "When true, includes balances for tokens without available pricing data. By default, unpriced token balances are excluded.",
+            "description": "When true, excludes balances for tokens without available pricing data. By default, unpriced token balances are included.",
             "required": false,
             "schema": {
               "type": "boolean",

--- a/token-filtering.mdx
+++ b/token-filtering.mdx
@@ -69,10 +69,10 @@ The following examples demonstrate how to use this data to create robust filteri
 
 Use the optional `exclude_spam_tokens` query parameter on the EVM Balances API to automatically filter out tokens with less than 100 USD of liquidity. Include `exclude_spam_tokens=true` to have those tokens excluded from the response entirely.
 
-By default, balances for tokens without available pricing data are also excluded. Set `include_unpriced=true` if you want those unpriced token balances returned.
+By default, balances for tokens without available pricing data are included. Set `exclude_unpriced=true` if you want those unpriced token balances filtered out.
 
 ```bash
-curl -s -X GET 'https://api.sim.dune.com/v1/evm/balances/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045?exclude_spam_tokens=true&include_unpriced=true' \
+curl -s -X GET 'https://api.sim.dune.com/v1/evm/balances/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045?exclude_spam_tokens=true&exclude_unpriced=true' \
   -H 'X-Sim-Api-Key: YOUR_API_KEY'
 ```
 

--- a/token-filtering.mdx
+++ b/token-filtering.mdx
@@ -69,8 +69,10 @@ The following examples demonstrate how to use this data to create robust filteri
 
 Use the optional `exclude_spam_tokens` query parameter on the EVM Balances API to automatically filter out tokens with less than 100 USD of liquidity. Include `exclude_spam_tokens=true` to have those tokens excluded from the response entirely.
 
+By default, balances for tokens without available pricing data are also excluded. Set `include_unpriced=true` if you want those unpriced token balances returned.
+
 ```bash
-curl -s -X GET 'https://api.sim.dune.com/v1/evm/balances/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045?exclude_spam_tokens=true' \
+curl -s -X GET 'https://api.sim.dune.com/v1/evm/balances/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045?exclude_spam_tokens=true&include_unpriced=true' \
   -H 'X-Sim-Api-Key: YOUR_API_KEY'
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update previous docs/schema change to match latest echo rename and semantics
- rename `include_unpriced` -> `exclude_unpriced`
- keep default behavior backward-compatible: unpriced balances are included by default
- make filtering unpriced balances an explicit opt-in via `exclude_unpriced=true`

## Changes
- `openapi.json`
  - `GET /v1/evm/balances/{address}`: query param renamed to `exclude_unpriced` (boolean, default `false`)
  - `GET /v1/evm/balances/{address}/stablecoins`: same rename and semantics
  - descriptions updated to reflect: when true, unpriced balances are excluded; by default they are included
- `evm/balances.mdx`
  - section updated to **Exclude unpriced balances**
  - docs now state that unpriced balances are included by default; use `exclude_unpriced=true` to filter them out
- `token-filtering.mdx`
  - narrative updated to included-by-default behavior
  - curl example updated to use `exclude_unpriced=true`
- `.well-known/ai-tools.json`
  - balances and stablecoin tool input schemas renamed to `exclude_unpriced`
  - descriptions updated to exclusion semantics

## Validation
- no remaining `include_unpriced` references in repo
- `openapi.json` and `.well-known/ai-tools.json` parse successfully via `python3 -m json.tool`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duneanalytics.slack.com/archives/C0A6ZD7QYVC/p1775804196738129?thread_ts=1775804196.738129&cid=C0A6ZD7QYVC)

<div><a href="https://cursor.com/agents/bc-4a8c6af3-f5fa-5f71-95b3-9aef63376837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a8c6af3-f5fa-5f71-95b3-9aef63376837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

