### PR TITLE
Reduce DeFi Positions CU charge from 10 to 4

### DIFF
--- a/agent-reference.mdx
+++ b/agent-reference.mdx
@@ -65,7 +65,7 @@ Stable: `/v1/` · Beta: `/beta/`
 
 | Endpoint | Method | Path | CU | Key Parameters |
 |---|---|---|---|---|
-| DeFi Positions | GET | /v1/evm/defi/positions/{address} | 10N per chain | chain_ids |
+| DeFi Positions | GET | /v1/evm/defi/positions/{address} | 4N per chain | chain_ids |
 
 ## SVM Endpoints (Beta — /beta)
 
@@ -123,7 +123,7 @@ Warning: 200 responses can include `warnings[]` array (e.g., UNSUPPORTED_CHAIN_I
 | Balances (single token) | Fixed | 1 |
 | Stablecoins | Chain-dependent | N |
 | Collectibles | Chain-dependent | N |
-| DeFi Positions | Chain-dependent | 10N |
+| DeFi Positions | Chain-dependent | 4N |
 | Activity | Fixed | 3 |
 | Transactions (EVM & SVM) | Fixed | 1 |
 | Token Info | Fixed | 2 |

--- a/compute-units.mdx
+++ b/compute-units.mdx
@@ -17,7 +17,7 @@ If you omit the `chain_ids` parameter, the request uses the `default` chain set,
 | Balances (EVM & SVM) | Chain-dependent | N compute units, where N is the number of chains processed in the `chain_ids` query parameter after tag expansion | {<DefaultChainCount endpoint="balances" />} |
 | Balances (single token sub-path) | Fixed | 1 compute unit per request. Accepts exactly one `chain_ids` value (single chain only) | - |
 | Collectibles | Chain-dependent | N compute units, where N is the number of chains processed in the `chain_ids` query parameter after tag expansion | {<DefaultChainCount endpoint="collectibles" />} |
-| DeFi Positions | Chain-dependent | 10N compute units, where N is the number of chains processed in the `chain_ids` query parameter after tag expansion | 6 |
+| DeFi Positions | Chain-dependent | 4N compute units, where N is the number of chains processed in the `chain_ids` query parameter after tag expansion | 6 |
 | Activity | Fixed | 3 compute units per request | — |
 | Transactions (EVM & SVM) | Fixed | 1 compute unit per request | — |
 | Token Info | Fixed | 2 compute units per request, even though `chain_ids` is required | — |


### PR DESCRIPTION
## Summary
- Updates the DeFi Positions compute unit cost from 10N to 4N across `compute-units.mdx` and `agent-reference.mdx`

## Test plan
- [ ] Verify the Compute Units page table renders correctly with the updated value
- [ ] Verify the Agent Reference page reflects the updated CU cost