### PR TITLE
Add Search Tokens endpoint docs

### DIFF
--- a/compute-units.mdx
+++ b/compute-units.mdx
@@ -22,6 +22,7 @@ If you omit the `chain_ids` parameter, the request uses the `default` chain set,
 | Transactions (EVM & SVM) | Fixed | 1 compute unit per request | — |
 | Token Info | Fixed | 2 compute units per request, even though `chain_ids` is required | — |
 | Token Holders | Fixed | 2 compute units per request | — |
+| Search Tokens | Fixed | 2 compute units per request, regardless of how many `chain_ids` are included | — |
 | Subscriptions | Event-based | 2 compute units per event sent to your webhook. Note that a single webhook payload can contain multiple events. | All supported EVM chains (varies by subscription type) when chain_ids is omitted |
 
 ## How CUs work

--- a/docs.json
+++ b/docs.json
@@ -64,7 +64,8 @@
               "evm/defi/supported-protocols",
               "evm/transactions",
               "evm/token-info",
-              "evm/token-holders"
+              "evm/token-holders",
+              "evm/search-tokens"
             ]
           },
           {

--- a/evm/search-tokens.mdx
+++ b/evm/search-tokens.mdx
@@ -1,0 +1,110 @@
+---
+title: "Search Tokens"
+sidebarTitle: "Search Tokens"
+description: "Search ERC20 and ERC721 tokens across supported EVM chains by symbol or name, with optional chain and token-type filters. ERC20 results are enriched with logo and decimals."
+openapi: "/openapi.json GET /v1/evm/search/tokens"
+---
+
+The Search Tokens API lets you find ERC20 and ERC721 tokens by name or symbol across one or more supported EVM chains. Results are ranked by an internal score (where available) and returned with their canonical chain, address, symbol, and name. ERC20 results are additionally enriched with `logo` and `decimals` so they can be rendered immediately.
+
+Use it to power token-pickers, autocomplete inputs, and any UI flow where the user knows part of a token's name or symbol but not its contract address.
+
+## Example Request
+
+```bash
+curl -X GET "https://api.sim.dune.com/v1/evm/search/tokens?query=USDC&chain_ids=1,8453&limit=5" \
+     -H "X-Sim-Api-Key: YOUR_API_KEY"
+```
+
+```json Response (JSON) [expandable]
+[
+  {
+    "chain_id": 1,
+    "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    "token_type": "ERC20",
+    "symbol": "USDC",
+    "name": "USD Coin",
+    "logo": "https://api.sim.dune.com/beta/token/logo/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    "decimals": 6
+  },
+  {
+    "chain_id": 8453,
+    "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    "token_type": "ERC20",
+    "symbol": "USDC",
+    "name": "USD Coin",
+    "logo": "https://api.sim.dune.com/beta/token/logo/8453/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    "decimals": 6
+  }
+]
+```
+
+## Query Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `query` | string | yes | Search term matched against the token's `symbol` and `name`. Case-insensitive. **Minimum 3 characters** after trimming whitespace; shorter queries return an empty result set. |
+| `chain_ids` | string | no | Comma-separated chain IDs (`1,8453`) or a tag (`mainnet`, `default`). When omitted, all supported chains are searched. See the [Supported Chains](/evm/supported-chains#tags) page. |
+| `type` | string | no | Restrict results to a single token type. Accepted values: `erc20`, `erc721`. When omitted, both types are returned. Unknown values are treated as "no filter". |
+| `limit` | integer | no | Maximum number of results to return. Default `10`, maximum `50` — values above the maximum are clamped silently. Values below `1` are clamped to `1`. |
+
+## Response Fields
+
+The endpoint returns a JSON array of token objects. Each object has:
+
+| Field | Type | Description |
+|---|---|---|
+| `chain_id` | integer | EVM chain ID where the token is deployed |
+| `address` | string | The token's contract address (lowercase, `0x`-prefixed) |
+| `token_type` | string | `"ERC20"` or `"ERC721"` |
+| `symbol` | string | Token symbol (e.g. `USDC`, `BAYC`) |
+| `name` | string | Token name (e.g. `USD Coin`, `Bored Ape Yacht Club`) |
+| `logo` | string \| null | Logo URL when available. Populated for ERC20s with metadata; `null` for ERC721s and ERC20s without a known logo. |
+| `decimals` | integer \| null | Token decimals. Populated for ERC20s with metadata; `null` for ERC721s and ERC20s without a known decimals value. |
+
+<Note>
+  Only ERC20 results are enriched with `logo` and `decimals`. ERC721 results always return `null` for both fields — collectible metadata is available via the [Collectibles](/evm/collectibles) endpoint.
+</Note>
+
+## How Search Works
+
+Search is powered by an in-memory **trigram index** built over each token's `symbol` and `name`. Properties:
+
+- **Case-insensitive.** `usdc` and `USDC` match the same set of tokens.
+- **Substring-friendly.** `BAY` matches `BAYC`, `Bored Ape Yacht Club`, and similar.
+- **Three-character minimum.** Queries of fewer than 3 characters (after trimming) return an empty array — trigrams need at least 3 characters of input.
+- **Ranked.** Tokens with an internal ranking score (driven by activity / liquidity signals) appear first. Ties fall back to a deterministic `(chain_id ASC, address ASC)` ordering, so repeat queries return stable results.
+
+## Filtering Examples
+
+**Restrict to a single chain**
+
+```bash
+curl "https://api.sim.dune.com/v1/evm/search/tokens?query=USDC&chain_ids=8453" \
+     -H "X-Sim-Api-Key: YOUR_API_KEY"
+```
+
+**Restrict to ERC721 collections only**
+
+```bash
+curl "https://api.sim.dune.com/v1/evm/search/tokens?query=BAYC&type=erc721" \
+     -H "X-Sim-Api-Key: YOUR_API_KEY"
+```
+
+**Search across the default chain set**
+
+```bash
+curl "https://api.sim.dune.com/v1/evm/search/tokens?query=Tether&chain_ids=default" \
+     -H "X-Sim-Api-Key: YOUR_API_KEY"
+```
+
+## Error Responses
+
+| Status | Cause |
+|---|---|
+| `400 Bad Request` | `query` parameter is missing or empty after trimming, or a query parameter cannot be parsed |
+| `401 Unauthorized` | Missing or invalid `X-Sim-Api-Key` header |
+
+## Compute Unit Cost
+
+The Search Tokens endpoint has a fixed CU cost of **2** per request. The `chain_ids` query parameter does not change the CU cost. See the [Compute Units](/compute-units) page for detailed information.

--- a/openapi.json
+++ b/openapi.json
@@ -2210,6 +2210,182 @@
         }
       }
     },
+    "/v1/evm/search/tokens": {
+      "get": {
+        "summary": "Search Tokens",
+        "description": "Search ERC20 and ERC721 tokens across supported EVM chains by symbol or name. Results are ranked by an internal score (where available) with deterministic `(chain_id ASC, address ASC)` tiebreak. ERC20 results are enriched with `logo` and `decimals`; ERC721 results return `null` for both fields. Search is case-insensitive and uses a trigram index — queries shorter than 3 characters (after trimming) return an empty array.",
+        "operationId": "searchEvmTokens",
+        "tags": [
+          "evm",
+          "search"
+        ],
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "Search term matched against the token's `symbol` and `name`. Case-insensitive. Minimum 3 characters after trimming whitespace; shorter queries return an empty result set.",
+            "schema": {
+              "type": "string",
+              "minLength": 3
+            },
+            "example": "USDC"
+          },
+          {
+            "name": "chain_ids",
+            "in": "query",
+            "required": false,
+            "description": "Filter by chain(s). Accepts numeric chain IDs and/or tags. Provide a single value (e.g. `?chain_ids=1` or `?chain_ids=mainnet`) or a comma-separated list (e.g. `?chain_ids=1,8453,testnet`). When omitted, all supported chains are searched. See the [Supported Chains Tags](/evm/supported-chains#tags) section.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "1,8453"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Restrict results to a single token type. When omitted, both types are returned. Unknown values are treated as no filter.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "erc20",
+                "erc721"
+              ]
+            },
+            "example": "erc20"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return. Default is 10 when not provided. Values above 50 are clamped to 50; values below 1 are clamped to 1.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of matching tokens, ranked by relevance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenSearchResponse"
+                },
+                "examples": {
+                  "success": {
+                    "value": [
+                      {
+                        "chain_id": 1,
+                        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                        "token_type": "ERC20",
+                        "symbol": "USDC",
+                        "name": "USD Coin",
+                        "logo": "https://api.sim.dune.com/beta/token/logo/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                        "decimals": 6
+                      },
+                      {
+                        "chain_id": 8453,
+                        "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+                        "token_type": "ERC20",
+                        "symbol": "USDC",
+                        "name": "USD Coin",
+                        "logo": "https://api.sim.dune.com/beta/token/logo/8453/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+                        "decimals": 6
+                      }
+                    ]
+                  },
+                  "empty": {
+                    "summary": "No matches",
+                    "value": []
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Missing or empty `query` parameter, or unparseable query parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenHolders_ErrorResponse"
+                },
+                "examples": {
+                  "missingQuery": {
+                    "summary": "Missing query parameter",
+                    "value": {
+                      "error": {
+                        "message": "Missing required parameter: query",
+                        "code": "BAD_REQUEST"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayErrorResponse"
+                },
+                "examples": {
+                  "invalidApiKey": {
+                    "value": {
+                      "error": "invalid API Key"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate Limit Exceeded - Too many requests.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayErrorResponse"
+                },
+                "examples": {
+                  "rateLimitExceeded": {
+                    "value": {
+                      "error": "Too many requests. Please contact sales@dune.com to increase your limit."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error - Server-side error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenHolders_ErrorResponse"
+                },
+                "examples": {
+                  "internalServerError": {
+                    "value": {
+                      "error": {
+                        "message": "Server-side error",
+                        "code": "INTERNAL_SERVER_ERROR"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/evm/token-info/{address}": {
       "get": {
         "tags": [
@@ -5723,6 +5899,70 @@
             "description": "An opaque token for fetching the next page of results. Null if no more results.",
             "example": "eyJvZmZzZXQiOjEwMH0="
           }
+        }
+      },
+      "TokenSearchResult": {
+        "type": "object",
+        "description": "A single token matched by the search index. ERC20 results include `logo` and `decimals`; ERC721 results return `null` for both.",
+        "properties": {
+          "chain_id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "EVM chain ID where the token is deployed.",
+            "example": 1
+          },
+          "address": {
+            "type": "string",
+            "format": "address",
+            "pattern": "^0x[a-fA-F0-9]{40}$",
+            "description": "The token's contract address (lowercase, 0x-prefixed).",
+            "example": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          },
+          "token_type": {
+            "type": "string",
+            "enum": [
+              "ERC20",
+              "ERC721"
+            ],
+            "description": "The token standard. Canonical uppercase form."
+          },
+          "symbol": {
+            "type": "string",
+            "description": "Token symbol (e.g. `USDC`, `BAYC`).",
+            "example": "USDC"
+          },
+          "name": {
+            "type": "string",
+            "description": "Token name (e.g. `USD Coin`, `Bored Ape Yacht Club`).",
+            "example": "USD Coin"
+          },
+          "logo": {
+            "type": "string",
+            "nullable": true,
+            "description": "Logo URL when available. Populated for ERC20s with metadata; `null` for ERC721s and for ERC20s without a known logo.",
+            "example": "https://api.sim.dune.com/beta/token/logo/1/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          },
+          "decimals": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "description": "Token decimals. Populated for ERC20s with metadata; `null` for ERC721s and for ERC20s without a known decimals value.",
+            "example": 6
+          }
+        },
+        "required": [
+          "chain_id",
+          "address",
+          "token_type",
+          "symbol",
+          "name"
+        ]
+      },
+      "TokenSearchResponse": {
+        "type": "array",
+        "description": "Search results, ranked by internal score then `(chain_id ASC, address ASC)` for stable ordering. May be empty.",
+        "items": {
+          "$ref": "#/components/schemas/TokenSearchResult"
         }
       },
       "TokenInfo": {


### PR DESCRIPTION
Document the new GET /v1/evm/search/tokens endpoint:
- evm/search-tokens.mdx: page with query/chain_ids/type/limit params, example responses, trigram index notes, error responses
- openapi.json: searchEvmTokens path + TokenSearchResponse and TokenSearchResult schemas; reuses TokenHolders_ErrorResponse and GatewayErrorResponse for consistency
- docs.json: nav entry under EVM
- compute-units.mdx: Search Tokens row (fixed 2 CU per request)